### PR TITLE
Fix "Consider an iterator instead of materializing the list" issue

### DIFF
--- a/fprettify/tests/__init__.py
+++ b/fprettify/tests/__init__.py
@@ -155,6 +155,6 @@ if not os.path.exists(RESULT_FILE):
     io.open(RESULT_FILE, 'w', encoding='utf-8').close()
 
 for dirpath, dirnames, filenames in os.walk(BEFORE_DIR):
-    for example in [f for f in filenames if any([f.endswith(_) for _ in FORTRAN_EXTENSIONS])]:
+    for example in [f for f in filenames if any( f.endswith(_) for _ in FORTRAN_EXTENSIONS)]:
         addtestmethod(FPrettifyTestCase, dirpath.replace(
             BEFORE_DIR, u""), example)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider an iterator instead of materializing the list](https://www.quantifiedcode.com/app/issue_class/53lnAzfW)
Issue details: [https://www.quantifiedcode.com/app/project/gh:pseewald:fprettify?groups=code_patterns/%3A53lnAzfW](https://www.quantifiedcode.com/app/project/gh:pseewald:fprettify?groups=code_patterns/%3A53lnAzfW)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)