### PR TITLE
add pre-commit-hooks definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: fprettify
+  name: auto-formatter for modern fortran source code
+  description: imposes strict whitespace formatting for modern (F90+) Fortran code
+  entry: fprettify
+  language: python
+  files: \.[fF]\d*$

--- a/hooks.yml
+++ b/hooks.yml
@@ -1,0 +1,1 @@
+.pre-commit-hooks.yaml


### PR DESCRIPTION
makes it possible to use `fprettify` as a pre-commit-hook with https://pre-commit.com