### PR TITLE
Add --enable-swap-case: change known keywords and constants character…

### DIFF
--- a/fortran_tests/after/example_swapcase.f90
+++ b/fortran_tests/after/example_swapcase.f90
@@ -1,0 +1,304 @@
+
+module exAmple
+   implicit none
+   private
+   public :: dp, test_routine, &
+             test_function, test_type, str_function
+
+! Comment, should not change case nor spaces
+!!$   INTEGER,   PARAMETER :: dp = SELECTED_REAL_KIND ( 15 , 307)
+!!$   TYPE  test_type
+!!$      REAL  (kind =dp ) :: r = 1.0d-3
+!!$      INTEGER :: i
+!!$   END TYPE test_type
+!!$
+!!$
+!!$CONTAINS
+!!$
+!!$
+!!$   SUBROUTINE test_routine( &
+!!$   r, i, j, k, l)
+!!$        INTEGER, INTENT(in)                                :: r, i, j, k
+!!$       INTEGER,   INTENT (out)                               :: l
+!!$
+!!$    l  = test_function(r,i,j,k)
+!!$ END &
+!!$SUBROUTINE
+
+   integer, parameter :: SELECTED_REAL_KIND = 1*2
+   integer, parameter :: dp1 = selected_real_kind(15, 307) ! SELECTED_REAL_KIND ( 15 , 307) !should not change case in comment
+
+   character(len=*), parameter :: a = 'integer,   parameter'//'b'!should not change case in string
+   character(len=*), parameter :: b = "integer,   parameter" !should not change case in string
+   character(len=*), parameter :: c = 'integer,   "parameter"' !should not change case in string
+   character(len=*), parameter :: d = "integer,   'parameter" !should not change case in string
+
+   integer(kind=INT64), parameter :: l64 = 2_INT64
+   real(kind=REAL64), parameter :: r64a = 2._REAL64
+   real(kind=REAL64), parameter :: r64b = 2.0_REAL64
+   real(kind=REAL64), parameter :: r64c = .0_REAL64
+   real(kind=REAL64), parameter :: r64a = 2.e3_real64
+   real(kind=REAL64), parameter :: r64b = 2.0E3_REAL64
+   real(kind=REAL64), parameter :: r64c = .0E3_REAL64
+
+   integer, parameter :: dp = selected_real_kind(15, 307)
+   type test_type
+      real(kind=dp) :: r = 1.0d-3
+      integer :: i
+   end type test_type
+
+contains
+
+   subroutine test_routine( &
+      r, i, j, k, l)
+      use ISO_FORTRAN_ENV, only: INT64
+      integer, intent(in)                                :: r, i, j, k
+      integer, intent(out)                               :: l
+
+      integer(kind=INT64) :: l64
+
+      l = test_function(r, i, j, k)
+
+      l64 = 2_INT64
+      if (l .eq. 2) l = max(l64, 2_INT64)
+      if (l .eq. 2) l = max(l64, 2_INT64)
+      if (l .eq. 2) l = max
+
+   end &
+      subroutine
+
+   pure function test_function(r, i, j, &
+                               k) &
+      result(l)
+      integer, intent(in)                                :: r, i, j, k
+      integer                                            :: l
+
+      l = r + i + j + k
+   end function
+   function &
+      str_function(a) result(l)
+      character(len=*)                                   :: a
+      integer                                            :: l
+
+      if (len(a) < 5) then
+         l = 0
+      else
+         l = 1
+      endif
+   end function
+
+end module
+
+program example_prog
+   use example, only: dp, test_routine, test_function, test_type, str_function
+
+   implicit none
+   integer :: r, i, j, k, l, my_integer, m
+   integer, dimension(5) :: arr
+   integer, dimension(20) :: big_arr
+   integer :: endif
+   type(test_type) :: t
+   real(kind=dp) :: r1, r2, r3, r4, r5, r6
+   integer, pointer :: point
+
+   point => null()
+
+! 1) white space formatting !
+!***************************!
+! example 1.1
+   r = 1; i = -2; j = 3; k = 4; l = 5
+   r2 = 0.0_dp; r3 = 1.0_dp; r4 = 2.0_dp; r5 = 3.0_dp; r6 = 4.0_dp
+   r1 = -(r2**i*(r3 + r5*(-r4) - r6)) - 2.e+2
+   if (r .eq. 2 .and. r <= 5) i = 3
+   write (*, *) (merge(3, 1, i <= 2))
+   write (*, *) test_function(r, i, j, k)
+   t%r = 4.0_dp
+   t%i = str_function("t  % i   =  ")
+
+! example 1.2
+   my_integer = 2
+   i = 3
+   j = 5
+
+   big_arr = [1, 2, 3, 4, 5, &
+              6, 7, 8, 9, 10, &
+              11, 12, 13, 14, 15, &
+              16, 17, 18, 19, 20]
+
+! example 1.3: disabling auto-formatter:
+   my_integer = 2 !&
+   i          = 3 !&
+   j          = 5 !&
+
+!&<
+   my_integer = 2
+   i          = 3
+   j          = 5
+!&>
+
+   big_arr = [ 1,  2,  3,  4,  5, & !&
+               6,  7,  8,  9, 10, & !&
+              11, 12, 13, 14, 15, & !&
+              16, 17, 18, 19, 20] !&
+
+! example 1.4:
+
+   big_arr = [1, 2, 3, 4, 5,&
+           &  6, 7, 8, 9, 10, &
+           & 11, 12, 13, 14, 15,&
+            &16, 17, 18, 19, 20]
+
+! 2) auto indentation for loops !
+!*******************************!
+
+! example 2.1
+   l = 0
+   do r = 1, 10
+      select case (r)
+      case (1)
+         do_label: do i = 1, 100
+            if (i <= 2) then
+               m = 0
+               do while (m < 4)
+                  m = m + 1
+                  do k = 1, 3
+                     if (k == 1) l = l + 1
+                  end do
+               enddo
+            endif
+         enddo do_label
+      case (2)
+         l = i + j + k
+      end select
+   enddo
+
+! example 2.2
+   do m = 1, 2
+      do r = 1, 3
+         write (*, *) r
+         do k = 1, 4
+         do l = 1, 3
+         do i = 4, 5
+            do my_integer = 1, 1
+            do j = 1, 2
+               write (*, *) test_function(m, r, k, l) + i
+            enddo
+            enddo
+         enddo
+         enddo
+         enddo
+      enddo
+   enddo
+
+! 3) auto alignment for linebreaks   !
+!************************************!
+
+! example 3.1
+   l = test_function(1, 2, test_function(1, 2, 3, 4), 4) + 3*(2 + 1)
+
+   l = test_function(1, 2, test_function(1, 2, 3, 4), 4) + &
+       3*(2 + 1)
+
+   l = test_function(1, 2, &
+                     test_function(1, 2, 3, 4), 4) + &
+       3*(2 + 1)
+
+   l = test_function(1, 2, &
+                     test_function(1, 2, 3, &
+                                   4), 4) + &
+       3*(2 + 1)
+
+! example 3.2
+   arr = [1, (/3, 4, 5/), 6] + [1, 2, 3, 4, 5]
+
+   arr = [1, (/3, 4, 5/), &
+          6] + [1, 2, 3, 4, 5]
+
+   arr = [1, (/3, 4, 5/), &
+          6] + &
+         [1, 2, 3, 4, 5]
+
+   arr = [1, (/3, 4, &
+               5/), &
+          6] + &
+         [1, 2, 3, 4, 5]
+
+! example 3.3
+   l = test_function(1, 2, &
+                     3, 4)
+
+   l = test_function( &
+       1, 2, 3, 4)
+
+   arr = [1, 2, &
+          3, 4, 5]
+   arr = [ &
+         1, 2, 3, 4, 5]
+
+! 4) more complex formatting and tricky test cases !
+!**************************************************!
+
+! example 4.1
+   l = 0
+   do r = 1, 10
+      select case (r)
+      case (1)
+         do i = 1, 100; if (i <= 2) then! comment
+               do j = 1, 5
+                  do k = 1, 3
+                     l = l + 1
+! unindented comment
+                     ! indented comment
+                  end do; enddo
+            elseif (.NOT. j == 4) then
+               my_integer = 4
+            else
+               write (*, *) " hello"
+            endif
+         enddo
+      case (2)
+         l = i + j + k
+      end select
+   enddo
+
+! example 4.2
+   if ( &
+      l == &
+      111) &
+      then
+      do k = 1, 2
+         if (k == 1) &
+            l = test_function(1, &
+                              test_function(r=4, i=5, &
+                                            j=6, k=test_function(1, 2*(3*(1 + 1)), str_function(")a!(b['(;=dfe"), &
+                                                                 9) + &
+                                            test_function(1, 2, 3, 4)), 9, 10) &
+                ! test_function(1,2,3,4)),9,10) &
+                ! +13*str_function('') + str_function('"')
+                + 13*str_function('') + str_function('"')
+      end & ! comment
+         ! comment
+         do
+   endif
+
+! example 4.3
+   arr = [1, (/3, 4, &
+               5/), &
+          6] + &
+         [1, 2, 3, 4, 5]; arr = [1, 2, &
+ 3, 4, 5]
+
+! example 4.4
+   endif = 3
+   if (endif == 2) then
+      endif = 5
+   else if (endif == 3) then
+      write (*, *) endif
+   endif
+
+! example 4.5
+   do i = 1, 2; if (.true.) then
+         write (*, *) "hello"
+      endif; enddo
+
+end program

--- a/fortran_tests/after/example_swapcase.f90-enabled
+++ b/fortran_tests/after/example_swapcase.f90-enabled
@@ -1,8 +1,8 @@
 
-MODULE exAmple
-   IMPLICIT NONE
-   PRIVATE
-   PUBLIC :: dp, test_routine, &
+module exAmple
+   implicit none
+   private
+   public :: dp, test_routine, &
              test_function, test_type, str_function
 
 ! Comment, should not change case nor spaces
@@ -25,94 +25,94 @@ MODULE exAmple
 !!$ END &
 !!$SUBROUTINE
 
-   INTEGER, PARAMETER :: SELECTED_REAL_KIND = 1*2
-   INTEGER, PARAMETER :: dp1 = SELECTED_REAL_KIND(15, 307) ! SELECTED_REAL_KIND ( 15 , 307) !should not change case in comment
+   integer, parameter :: SELECTED_REAL_KIND = 1*2
+   integer, parameter :: dp1 = selected_real_kind(15, 307) ! SELECTED_REAL_KIND ( 15 , 307) !should not change case in comment
 
    character(len=*), parameter :: a = 'INTEGER,   PARAMETER'//'b'!should not change case in string
    character(len=*), parameter :: b = "INTEGER,   PARAMETER" !should not change case in string
    character(len=*), parameter :: c = 'INTEGER,   "PARAMETER"' !should not change case in string
    character(len=*), parameter :: d = "INTEGER,   'PARAMETER" !should not change case in string
 
-   INTEGER(kind=int64), parameter :: l64 = 2_int64
-   REAL(kind=real64), parameter :: r64a = 2._real64
-   REAL(kind=real64), parameter :: r64b = 2.0_real64
-   REAL(kind=real64), parameter :: r64c = .0_real64
-   REAL(kind=real64), parameter :: r64a = 2.e3_real64
-   REAL(kind=real64), parameter :: r64b = 2.0e3_real64
-   REAL(kind=real64), parameter :: r64c = .0e3_real64
+   integer(kind=INT64), parameter :: l64 = 2_INT64
+   real(kind=REAL64), parameter :: r64a = 2._REAL64
+   real(kind=REAL64), parameter :: r64b = 2.0_REAL64
+   real(kind=REAL64), parameter :: r64c = .0_REAL64
+   real(kind=REAL64), parameter :: r64a = 2.E3_REAL64
+   real(kind=REAL64), parameter :: r64b = 2.0E3_REAL64
+   real(kind=REAL64), parameter :: r64c = .0E3_REAL64
 
-   INTEGER, PARAMETER :: dp = SELECTED_REAL_KIND(15, 307)
-   TYPE test_type
-      REAL(kind=dp) :: r = 1.0d-3
-      INTEGER :: i
-   END TYPE test_type
+   integer, parameter :: dp = selected_real_kind(15, 307)
+   type test_type
+      real(kind=dp) :: r = 1.0D-3
+      integer :: i
+   end type test_type
 
-CONTAINS
+contains
 
-   SUBROUTINE test_routine( &
+   subroutine test_routine( &
       r, i, j, k, l)
-      USE iso_fortran_env, only: int64
-      INTEGER, INTENT(in)                                :: r, i, j, k
-      INTEGER, INTENT(out)                               :: l
+      use ISO_FORTRAN_ENV, only: INT64
+      integer, intent(in)                                :: r, i, j, k
+      integer, intent(out)                               :: l
 
-      INTEGER(kind=int64) :: l64
+      integer(kind=INT64) :: l64
 
       l = test_function(r, i, j, k)
 
-      l64 = 2_int64
-      IF (l .EQ. 2) l = max(l64, 2_int64)
-      IF (l .EQ. 2) l = max(l64, 2_int64)
-      IF (l .EQ. 2) l = max
+      l64 = 2_INT64
+      if (l .eq. 2) l = max(l64, 2_INT64)
+      if (l .eq. 2) l = max(l64, 2_INT64)
+      if (l .eq. 2) l = max
 
-   END &
-      SUBROUTINE
+   end &
+      subroutine
 
-   PURE FUNCTION test_function(r, i, j, &
+   pure function test_function(r, i, j, &
                                k) &
-      RESULT(l)
-      INTEGER, INTENT(in)                                :: r, i, j, k
-      INTEGER                                            :: l
+      result(l)
+      integer, intent(in)                                :: r, i, j, k
+      integer                                            :: l
 
       l = r + i + j + k
-   END FUNCTION
-   FUNCTION &
-      str_function(a) RESULT(l)
-      CHARACTER(len=*)                                   :: a
-      INTEGER                                            :: l
+   end function
+   function &
+      str_function(a) result(l)
+      character(len=*)                                   :: a
+      integer                                            :: l
 
-      IF (LEN(a) < 5) THEN
+      if (len(a) < 5) then
          l = 0
-      ELSE
+      else
          l = 1
-      ENDIF
-   END FUNCTION
+      endif
+   end function
 
-END MODULE
+end module
 
-PROGRAM example_prog
-   USE example, ONLY: dp, test_routine, test_function, test_type, str_function
+program example_prog
+   use example, only: dp, test_routine, test_function, test_type, str_function
 
-   IMPLICIT NONE
-   INTEGER :: r, i, j, k, l, my_integer, m
-   INTEGER, DIMENSION(5) :: arr
-   INTEGER, DIMENSION(20) :: big_arr
-   INTEGER :: ENDIF
-   TYPE(test_type) :: t
-   REAL(kind=dp) :: r1, r2, r3, r4, r5, r6
-   INTEGER, POINTER :: point
+   implicit none
+   integer :: r, i, j, k, l, my_integer, m
+   integer, dimension(5) :: arr
+   integer, dimension(20) :: big_arr
+   integer :: endif
+   type(test_type) :: t
+   real(kind=dp) :: r1, r2, r3, r4, r5, r6
+   integer, pointer :: point
 
-   point => NULL()
+   point => null()
 
 ! 1) white space formatting !
 !***************************!
 ! example 1.1
    r = 1; i = -2; j = 3; k = 4; l = 5
-   r2 = 0.0_dp; r3 = 1.0_dp; r4 = 2.0_dp; r5 = 3.0_dp; r6 = 4.0_dp
-   r1 = -(r2**i*(r3 + r5*(-r4) - r6)) - 2.e+2
-   IF (r .EQ. 2 .AND. r <= 5) i = 3
-   WRITE (*, *) (MERGE(3, 1, i <= 2))
-   WRITE (*, *) test_function(r, i, j, k)
-   t%r = 4.0_dp
+   r2 = 0.0_DP; r3 = 1.0_DP; r4 = 2.0_DP; r5 = 3.0_DP; r6 = 4.0_DP
+   r1 = -(r2**i*(r3 + r5*(-r4) - r6)) - 2.E+2
+   if (r .eq. 2 .and. r <= 5) i = 3
+   write (*, *) (merge(3, 1, i <= 2))
+   write (*, *) test_function(r, i, j, k)
+   t%r = 4.0_DP
    t%i = str_function("t  % i   =  ")
 
 ! example 1.2
@@ -153,42 +153,42 @@ PROGRAM example_prog
 
 ! example 2.1
    l = 0
-   DO r = 1, 10
-      SELECT CASE (r)
-      CASE (1)
-         do_label: DO i = 1, 100
-            IF (i <= 2) THEN
+   do r = 1, 10
+      select case (r)
+      case (1)
+         do_label: do i = 1, 100
+            if (i <= 2) then
                m = 0
-               DO WHILE (m < 4)
+               do while (m < 4)
                   m = m + 1
-                  DO k = 1, 3
-                     IF (k == 1) l = l + 1
-                  END DO
-               ENDDO
-            ENDIF
-         ENDDO do_label
-      CASE (2)
+                  do k = 1, 3
+                     if (k == 1) l = l + 1
+                  end do
+               enddo
+            endif
+         enddo do_label
+      case (2)
          l = i + j + k
-      END SELECT
-   ENDDO
+      end select
+   enddo
 
 ! example 2.2
-   DO m = 1, 2
-      DO r = 1, 3
-         WRITE (*, *) r
-         DO k = 1, 4
-         DO l = 1, 3
-         DO i = 4, 5
-            DO my_integer = 1, 1
-            DO j = 1, 2
-               WRITE (*, *) test_function(m, r, k, l) + i
-            ENDDO
-            ENDDO
-         ENDDO
-         ENDDO
-         ENDDO
-      ENDDO
-   ENDDO
+   do m = 1, 2
+      do r = 1, 3
+         write (*, *) r
+         do k = 1, 4
+         do l = 1, 3
+         do i = 4, 5
+            do my_integer = 1, 1
+            do j = 1, 2
+               write (*, *) test_function(m, r, k, l) + i
+            enddo
+            enddo
+         enddo
+         enddo
+         enddo
+      enddo
+   enddo
 
 ! 3) auto alignment for linebreaks   !
 !************************************!
@@ -240,34 +240,34 @@ PROGRAM example_prog
 
 ! example 4.1
    l = 0
-   DO r = 1, 10
-      SELECT CASE (r)
-      CASE (1)
-         DO i = 1, 100; IF (i <= 2) THEN! comment
-               DO j = 1, 5
-                  DO k = 1, 3
+   do r = 1, 10
+      select case (r)
+      case (1)
+         do i = 1, 100; if (i <= 2) then! comment
+               do j = 1, 5
+                  do k = 1, 3
                      l = l + 1
 ! unindented comment
                      ! indented comment
-                  END DO; ENDDO
-            ELSEIF (.NOT. j == 4) THEN
+                  end do; enddo
+            elseif (.not. j == 4) then
                my_integer = 4
-            ELSE
-               WRITE (*, *) " hello"
-            ENDIF
-         ENDDO
-      CASE (2)
+            else
+               write (*, *) " hello"
+            endif
+         enddo
+      case (2)
          l = i + j + k
-      END SELECT
-   ENDDO
+      end select
+   enddo
 
 ! example 4.2
-   IF ( &
+   if ( &
       l == &
       111) &
-      THEN
-      DO k = 1, 2
-         IF (k == 1) &
+      then
+      do k = 1, 2
+         if (k == 1) &
             l = test_function(1, &
                               test_function(r=4, i=5, &
                                             j=6, k=test_function(1, 2*(3*(1 + 1)), str_function(")a!(b['(;=dfe"), &
@@ -276,10 +276,10 @@ PROGRAM example_prog
                 ! test_function(1,2,3,4)),9,10) &
                 ! +13*str_function('') + str_function('"')
                 + 13*str_function('') + str_function('"')
-      END & ! comment
+      end & ! comment
          ! comment
-         DO
-   ENDIF
+         do
+   endif
 
 ! example 4.3
    arr = [1, (/3, 4, &
@@ -289,16 +289,16 @@ PROGRAM example_prog
  3, 4, 5]
 
 ! example 4.4
-   ENDIF = 3
-   IF (ENDIF == 2) THEN
-      ENDIF = 5
-   ELSE IF (ENDIF == 3) THEN
-      WRITE (*, *) ENDIF
-   ENDIF
+   endif = 3
+   if (endif == 2) then
+      endif = 5
+   else if (endif == 3) then
+      write (*, *) endif
+   endif
 
 ! example 4.5
-   DO i = 1, 2; IF (.TRUE.) THEN
-         WRITE (*, *) "hello"
-      ENDIF; ENDDO
+   do i = 1, 2; if (.true.) then
+         write (*, *) "hello"
+      endif; enddo
 
-END PROGRAM
+end program

--- a/fortran_tests/before/example_swapcase.f90
+++ b/fortran_tests/before/example_swapcase.f90
@@ -1,0 +1,307 @@
+
+MODULE exAmple
+    IMPLICIT NONE
+   PRIVATE
+     PUBLIC :: dp, test_routine, &
+                 test_function,  test_type,    str_function
+
+! Comment, should not change case nor spaces
+!!$   INTEGER,   PARAMETER :: dp = SELECTED_REAL_KIND ( 15 , 307)
+!!$   TYPE  test_type
+!!$      REAL  (kind =dp ) :: r = 1.0d-3
+!!$      INTEGER :: i
+!!$   END TYPE test_type
+!!$
+!!$
+!!$CONTAINS
+!!$
+!!$
+!!$   SUBROUTINE test_routine( &
+!!$   r, i, j, k, l)
+!!$        INTEGER, INTENT(in)                                :: r, i, j, k
+!!$       INTEGER,   INTENT (out)                               :: l
+!!$
+!!$    l  = test_function(r,i,j,k)
+!!$ END &
+!!$SUBROUTINE
+
+   INTEGER,   PARAMETER :: SELECTED_REAL_KIND = 1*2
+   INTEGER,   PARAMETER :: dp1 = SELECTED_REAL_KIND ( 15 , 307) ! SELECTED_REAL_KIND ( 15 , 307) !should not change case in comment
+
+  character(len=*), parameter :: a = 'INTEGER,   PARAMETER' // 'b'!should not change case in string
+  character(len=*), parameter :: b = "INTEGER,   PARAMETER" !should not change case in string
+  character(len=*), parameter :: c = 'INTEGER,   "PARAMETER"' !should not change case in string
+  character(len=*), parameter :: d = "INTEGER,   'PARAMETER" !should not change case in string
+
+
+   INTEGER(kind=int64), parameter :: l64 = 2_int64
+   REAL(kind=real64), parameter :: r64a = 2._real64
+   REAL(kind=real64), parameter :: r64b = 2.0_real64
+   REAL(kind=real64), parameter :: r64c = .0_real64
+   REAL(kind=real64), parameter :: r64a = 2.e3_real64
+   REAL(kind=real64), parameter :: r64b = 2.0e3_real64
+   REAL(kind=real64), parameter :: r64c = .0e3_real64
+
+   INTEGER,   PARAMETER :: dp = SELECTED_REAL_KIND ( 15 , 307)
+   TYPE  test_type
+      REAL  (kind =dp ) :: r = 1.0d-3
+      INTEGER :: i
+   END TYPE test_type
+
+
+CONTAINS
+
+
+   SUBROUTINE test_routine( &
+   r, i, j, k, l)
+ USE iso_fortran_env, only: int64
+        INTEGER, INTENT(in)                                :: r, i, j, k
+       INTEGER,   INTENT (out)                               :: l
+
+    INTEGER(kind=int64) :: l64
+
+    l  = test_function(r,i,j,k)
+
+    l64 = 2_int64
+    IF (l.EQ.2) l=max(l64, 2_int64)
+    IF (l.EQ.2) l=max  (l64, 2_int64)
+    IF (l.EQ.2) l=max
+
+ END &
+SUBROUTINE
+
+ PURE FUNCTION test_function(r, i, j, &
+                                        k) &
+   RESULT(l)
+   INTEGER, INTENT(in)                                :: r, i, j, k
+   INTEGER                                            :: l
+
+      l=r + i +j  +k
+   END FUNCTION
+   FUNCTION &
+        str_function(a)      RESULT(l)
+      CHARACTER(len=*)                                   :: a
+      INTEGER                                            :: l
+
+     IF(LEN(a)<5)THEN
+       l=0
+      ELSE
+       l=1
+       ENDIF
+END FUNCTION
+
+END MODULE
+
+PROGRAM example_prog
+ USE example, ONLY: dp, test_routine, test_function, test_type,str_function
+
+   IMPLICIT  NONE
+  INTEGER :: r,i,j,k,l,my_integer,m
+     INTEGER, DIMENSION(5) :: arr
+   INTEGER, DIMENSION(20) :: big_arr
+INTEGER :: ENDIF
+   TYPE(test_type) :: t
+REAL(kind=dp) :: r1,   r2,  r3, r4, r5,  r6
+  INTEGER, POINTER :: point
+
+  point=>  NULL( )
+
+! 1) white space formatting !
+!***************************!
+! example 1.1
+   r=1;i=-2;j=3;k=4;l=5
+   r2  =  0.0_dp; r3= 1.0_dp;   r4 =2.0_dp; r5=3.0_dp;  r6 = 4.0_dp
+   r1=-(r2**i*(r3+r5*(-r4)-r6))-2.e+2
+   IF( r.EQ.2.AND.r<=5) i=3
+   WRITE(*, *)(MERGE(3, 1, i<=2))
+   WRITE(*, *)test_function(r,i,j , k)
+   t % r  = 4.0_dp
+   t%i  = str_function( "t  % i   =  " )
+
+! example 1.2
+   my_integer=2
+   i=3
+   j=5
+
+   big_arr = [1, 2, 3, 4, 5, &
+              6, 7, 8, 9, 10, &
+              11, 12, 13, 14, 15, &
+              16, 17, 18, 19, 20]
+
+! example 1.3: disabling auto-formatter:
+   my_integer = 2 !&
+   i          = 3 !&
+   j          = 5 !&
+
+!&<
+   my_integer = 2
+   i          = 3
+   j          = 5
+!&>
+
+   big_arr = [ 1,  2,  3,  4,  5, & !&
+               6,  7,  8,  9, 10, & !&
+              11, 12, 13, 14, 15, & !&
+              16, 17, 18, 19, 20] !&
+
+! example 1.4:
+
+   big_arr = [1, 2, 3, 4, 5,&
+           &  6, 7, 8, 9, 10, &
+           & 11, 12, 13, 14, 15,&
+            &16, 17, 18, 19, 20]
+
+! 2) auto indentation for loops !
+!*******************************!
+
+! example 2.1
+   l = 0
+   DO r=   1 , 10
+    SELECT CASE (r)
+      CASE(1)
+    do_label: DO i  =  1,100
+        IF  (i<=2)   THEN
+          m =0
+      DO WHILE(m <4)
+              m =m+1
+             DO k=1,3
+      IF (k==1)  l =l +1
+    END DO
+      ENDDO
+     ENDIF
+    ENDDO do_label
+    CASE ( 2 )
+      l=i + j + k
+      END SELECT
+   ENDDO
+
+! example 2.2
+   DO m = 1, 2
+     DO r = 1, 3
+        WRITE (*, *) r
+         DO k = 1, 4
+         DO l = 1, 3
+         DO i = 4, 5
+          DO my_integer = 1, 1
+          DO j = 1, 2
+          WRITE (*, *) test_function(m, r, k, l) + i
+            ENDDO
+            ENDDO
+         ENDDO
+        ENDDO
+          ENDDO
+      ENDDO
+   ENDDO
+
+! 3) auto alignment for linebreaks   !
+!************************************!
+
+! example 3.1
+   l = test_function(1, 2, test_function(1, 2, 3, 4), 4) + 3 *(2+1)
+
+   l = test_function (1, 2, test_function(1,2, 3, 4),4)  +&
+              3*(2+ 1 )
+
+   l =  test_function(1, 2,   &
+               test_function(1, 2,  3, 4),  4)+ &
+                                    3 * (2+1)
+
+   l = test_function(1, 2, &
+   test_function(1, 2, 3, &
+   4), 4) + &
+   3*(2 + 1)
+
+! example 3.2
+   arr = [1, (/3,4, 5/),   6] + [  1, 2,3, 4,5 ]
+
+   arr = [1,(/ 3, 4, 5 /) , &
+   6]  +[1,2, 3, 4, 5 ]
+
+   arr = [1,(/3,4,5/),  &
+   6]+ &
+             [1, 2, 3, 4, 5]
+
+   arr = [1, (/3, 4, &
+         5/), &
+         6] + &
+         [1, 2,3, 4, 5 ]
+
+! example 3.3
+   l = test_function(1, 2, &
+         3, 4)
+
+   l = test_function( &
+                  1, 2, 3, 4)
+
+   arr = [1, 2, &
+        3, 4, 5]
+   arr = [ &
+            1, 2, 3, 4, 5]
+
+! 4) more complex formatting and tricky test cases !
+!**************************************************!
+
+! example 4.1
+   l = 0
+   DO r = 1, 10
+         SELECT CASE ( r )
+   CASE( 1)
+           DO i=1,100;IF (i<=2) THEN! comment
+          DO j = 1,5
+                    DO   k= 1, 3
+                 l = l +  1
+! unindented comment
+         ! indented comment
+              END DO; ENDDO
+                ELSEIF ( .NOT. j ==4 ) THEN
+                  my_integer  =   4
+               ELSE
+            WRITE (*,*)   " hello"
+             ENDIF
+           ENDDO
+            CASE(2 )
+           l = i+ j + k
+              END SELECT
+               ENDDO
+
+! example 4.2
+   IF ( &
+    l == &
+       111) &
+         THEN
+       DO k = 1, 2
+   IF (k == 1) &
+               l = test_function(1, &
+                          test_function(r=4, i=5, &
+                      j=6, k=test_function(1,2*(3*(1 +1)), str_function ( ")a!(b['(;=dfe"), &
+                                                                 9) + &
+                            test_function(1, 2, 3, 4)), 9, 10) &
+                     ! test_function(1,2,3,4)),9,10) &
+            ! +13*str_function('') + str_function('"')
+                    + 13*str_function('') + str_function('"')
+                    END & ! comment
+          ! comment
+      DO
+       ENDIF
+
+! example 4.3
+   arr = [1,(/3,4, &
+      5 /),&
+          6 ]+ &
+    [1,2, 3, 4,5] ; arr = [1, 2,&
+       3, 4, 5]
+
+! example 4.4
+   ENDIF = 3
+   IF(ENDIF==2)THEN
+   ENDIF=5
+   ELSE IF(ENDIF==3)THEN
+   WRITE(*,*)ENDIF
+   ENDIF
+
+! example 4.5
+   DO i=1,2;IF(.TRUE.)THEN
+   WRITE(*, *)"hello"
+   ENDIF; ENDDO
+
+   END PROGRAM

--- a/fortran_tests/test_results/expected_results
+++ b/fortran_tests/test_results/expected_results
@@ -2177,3 +2177,4 @@ cp2k/src/xtb_coulomb.F : 1e5c4012509646e2b297fb2613978a86a834c14f48eae9757ce39fb
 cp2k/src/xtb_matrices.F : 0010210bbf4f670a0896b1ec96a37956567c85aa42f4342f026e37dc3ceebddd
 cp2k/src/xtb_parameters.F : 68f97eb0b60f8e3369c61a62aacd3f42e760b02f56c9e97fad48aa3f97d643de
 cp2k/src/xtb_types.F : e6301d8bafef54dab303d3f05e3ab05ae5a68ed70f078c681293a662eac5e0ad
+example_swapcase.f90 : aa4e030c700835a586a852d6ba3ae43fc72b22a1b6114f5d74d84ed719285bc8

--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -851,13 +851,15 @@ def replace_keywords_single_fline(f_line, case_dict):
     line_parts = [re.split('(\W)',a) for a in line_parts]  # problem, split "."
     line_parts = [b for a in line_parts for b in a]
 
+    swapcase = lambda s, a: s.lower() if a else s.upper()
+
     nbparts = len(line_parts)
     for pos, part in enumerate(line_parts):
         # exclude comments, strings:
         if part.strip() and not (part == '\n' or STR_OPEN_RE.match(part)):
             #print(len(line_parts),pos,repr(part))
             if F90_KEYWORDS_RE.match(part):
-                part = case_dict['keywords'](part)
+                part = swapcase(part, case_dict['keywords'])
             elif F90_PROCEDURES_RE.match(part):
                 ok = False
                 for pos2 in range(pos+1, nbparts):
@@ -866,18 +868,18 @@ def replace_keywords_single_fline(f_line, case_dict):
                         ok = (part2 == '(')
                         break
                 if ok:
-                    part = case_dict['procedures'](part)
+                    part = swapcase(part, case_dict['procedures'])
             elif F90_OPERATORS_RE.match(part):
                 pos1 = max(0, pos-1)
                 pos2 = min(pos+1, nbparts-1)
                 if line_parts[pos1] == line_parts[pos2] == '.':
-                    part = case_dict['operators'](part)
+                    part = swapcase(part, case_dict['operators'])
             elif F90_HPF_KEYWORDS_RE.match(part):
-                part = case_dict['keywords'](part)
+                part = swapcase(part, case_dict['keywords'])
             elif F90_CONSTANTS_RE.match(part):
-                part = case_dict['constants'](part)
+                part = swapcase(part, case_dict['constants'])
             elif F90_CONSTANTS_TYPES_RE.match(part):
-                part = case_dict['constants'](part)
+                part = swapcase(part, case_dict['constants'])
 
             line_parts[pos] = part
 
@@ -1754,11 +1756,13 @@ def run(argv=sys.argv):  # pragma: no cover
     ws_dict['intrinsics'] = args.whitespace_intrinsics
 
     # build swap case dictionary, could add option to select case
+    SWAP_TO_LOWER = True
+    SWAP_TO_UPPER = False
     case_dict = {
-        'keywords' : unicode.lower,
-        'procedures' : unicode.lower,
-        'operators' : unicode.lower,
-        'constants' : unicode.upper,
+        'keywords' : SWAP_TO_LOWER,
+        'procedures' : SWAP_TO_LOWER,
+        'operators' : SWAP_TO_LOWER,
+        'constants' : SWAP_TO_UPPER,
         }
 
     # support legacy input:

--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -228,6 +228,182 @@ NML_RE = re.compile(r"(/\w+/)", RE_FLAGS)
 NML_STMT_RE = re.compile(SOL_STR + r"NAMELIST.*/.*/", RE_FLAGS)
 DATA_STMT_RE = re.compile(SOL_STR + r"DATA\s+\w", RE_FLAGS)
 
+## Regexp for f90 keywords'
+F90_KEYWORDS_RE = re.compile(r"\b(" + "|".join((
+    "allocatable", "allocate", "assign", "assignment", "backspace",
+    "block", "call", "case", "character", "close", "common", "complex",
+    "contains", "continue", "cycle", "data", "deallocate",
+    "dimension", "do", "double", "else", "elseif", "elsewhere", "end",
+    "enddo", "endfile", "endif", "entry", "equivalence", "exit",
+    "external", "forall", "format", "function", "goto", "if",
+    "implicit", "include", "inquire", "integer", "intent",
+    "interface", "intrinsic", "logical", "module", "namelist", "none",
+    "nullify", "only", "open", "operator", "optional", "parameter",
+    "pause", "pointer", "precision", "print", "private", "procedure",
+    "program", "public", "read", "real", "recursive", "result", "return",
+    "rewind", "save", "select", "sequence", "stop", "subroutine",
+    "target", "then", "type", "use", "where", "while", "write",
+    ## F95 keywords.
+    "elemental", "pure",
+    ## F2003
+    "abstract", "associate", "asynchronous", "bind", "class",
+    "deferred", "enum", "enumerator", "extends", "extends_type_of",
+    "final", "generic", "import", "non_intrinsic", "non_overridable",
+    "nopass", "pass", "protected", "same_type_as", "value", "volatile",
+    ## F2008.
+    "contiguous", "submodule", "concurrent", "codimension",
+    "sync all", "sync memory", "critical", "image_index"
+    )) + r")\b", RE_FLAGS)
+
+## Regexp whose first part matches F90 intrinsic procedures.
+## Add a parenthesis to avoid catching non-procedures.
+F90_PROCEDURES_RE = re.compile(r"\b(" + "|".join((
+    "abs", "achar", "acos", "adjustl", "adjustr", "aimag", "aint",
+    "all", "allocated", "anint", "any", "asin", "associated",
+    "atan", "atan2", "bit_size", "btest", "ceiling", "char", "cmplx",
+    "conjg", "cos", "cosh", "count", "cshift", "date_and_time", "dble",
+    "digits", "dim", "dot_product", "dprod", "eoshift", "epsilon",
+    "exp", "exponent", "floor", "fraction", "huge", "iachar", "iand",
+    "ibclr", "ibits", "ibset", "ichar", "ieor", "index", "int", "ior",
+    "ishft", "ishftc", "kind", "lbound", "len", "len_trim", "lge", "lgt",
+    "lle", "llt", "log", "log10", "logical", "matmul", "max",
+    "maxexponent", "maxloc", "maxval", "merge", "min", "minexponent",
+    "minloc", "minval", "mod", "modulo", "mvbits", "nearest", "nint",
+    "not", "pack", "precision", "present", "product", "radix",
+    ## Real is taken out here to avoid highlighting declarations.
+    "random_number", "random_seed", "range", ## "real"
+    "repeat", "reshape", "rrspacing", "scale", "scan",
+    "selected_int_kind", "selected_real_kind", "set_exponent",
+    "shape", "sign", "sin", "sinh", "size", "spacing", "spread", "sqrt",
+    "sum", "system_clock", "tan", "tanh", "tiny", "transfer",
+    "transpose", "trim", "ubound", "unpack", "verify",
+    ## F95 intrinsic functions.
+    "null", "cpu_time",
+    ## F2003.
+    "move_alloc", "command_argument_count", "get_command",
+    "get_command_argument", "get_environment_variable",
+    "selected_char_kind", "wait", "flush", "new_line",
+    "extends", "extends_type_of", "same_type_as", "bind",
+    ## F2003 ieee_arithmetic intrinsic module.
+    "ieee_support_underflow_control", "ieee_get_underflow_mode",
+    "ieee_set_underflow_mode",
+    ## F2003 iso_c_binding intrinsic module.
+    "c_loc", "c_funloc", "c_associated", "c_f_pointer",
+    "c_f_procpointer",
+    ## F2008.
+    "bge", "bgt", "ble", "blt", "dshiftl", "dshiftr", "leadz", "popcnt",
+    "poppar", "trailz", "maskl", "maskr", "shifta", "shiftl", "shiftr",
+    "merge_bits", "iall", "iany", "iparity", "storage_size",
+    "bessel_j0", "bessel_j1", "bessel_jn",
+    "bessel_y0", "bessel_y1", "bessel_yn",
+    "erf", "erfc", "erfc_scaled", "gamma", "hypot", "log_gamma",
+    "norm2", "parity", "findloc", "is_contiguous",
+    "sync images", "lock", "unlock", "image_index",
+    "lcobound", "ucobound", "num_images", "this_image",
+    ## F2008 iso_fortran_env module.
+    "compiler_options", "compiler_version",
+    ## F2008 iso_c_binding module.
+    "c_sizeof"
+    )) + r")\b", RE_FLAGS)
+
+## Regexp matching intrinsic operators
+## F90_OPERATORS_RE = re.compile(r"\b\.(" + "|".join((
+##     "and", "eq", "eqv", "false", "ge", "gt", "le", "lt", "ne",
+##     "neqv", "not", "or", "true"
+##     )) + r")\.\b", RE_FLAGS)
+F90_OPERATORS_RE = re.compile(r"\b(" + "|".join((
+    "and", "eq", "eqv", "false", "ge", "gt", "le", "lt", "ne",
+    "neqv", "not", "or", "true"
+    )) + r")\b", RE_FLAGS)
+
+## Regexp for all HPF keywords, procedures and directives.
+F90_HPF_KEYWORDS_RE = re.compile(r"\b(" + "|".join((
+    ## Intrinsic procedures.
+    "all_prefix", "all_scatter", "all_suffix", "any_prefix",
+    "any_scatter", "any_suffix", "copy_prefix", "copy_scatter",
+    "copy_suffix", "count_prefix", "count_scatter", "count_suffix",
+    "grade_down", "grade_up",
+    "hpf_alignment", "hpf_distribution", "hpf_template", "iall", "iall_prefix",
+    "iall_scatter", "iall_suffix", "iany", "iany_prefix", "iany_scatter",
+    "iany_suffix", "ilen", "iparity", "iparity_prefix",
+    "iparity_scatter", "iparity_suffix", "leadz", "maxval_prefix",
+    "maxval_scatter", "maxval_suffix", "minval_prefix", "minval_scatter",
+    "minval_suffix", "number_of_processors", "parity",
+    "parity_prefix", "parity_scatter", "parity_suffix", "popcnt", "poppar",
+    "processors_shape", "product_prefix", "product_scatter",
+    "product_suffix", "sum_prefix", "sum_scatter", "sum_suffix",
+    ## Directives.
+    "align", "distribute", "dynamic", "independent", "inherit", "processors",
+    "realign", "redistribute", "template",
+    ## Keywords.
+    "block", "cyclic", "extrinsic", "new", "onto", "pure", "with"
+    )) + r")\b", RE_FLAGS)
+
+## Regexp for Fortran intrinsic constants
+F90_CONSTANTS_RE = re.compile(r"\b(" + "|".join((
+    ## F2003 iso_fortran_env constants.
+    "iso_fortran_env",
+    "input_unit", "output_unit", "error_unit",
+    "iostat_end", "iostat_eor",
+    "numeric_storage_size", "character_storage_size",
+    "file_storage_size",
+    ## F2003 iso_c_binding constants.
+    "iso_c_binding",
+    "c_int", "c_short", "c_long", "c_long_long", "c_signed_char",
+    "c_size_t",
+    "c_int8_t", "c_int16_t", "c_int32_t", "c_int64_t",
+    "c_int_least8_t", "c_int_least16_t", "c_int_least32_t",
+    "c_int_least64_t",
+    "c_int_fast8_t", "c_int_fast16_t", "c_int_fast32_t",
+    "c_int_fast64_t",
+    "c_intmax_t", "c_intptr_t",
+    "c_float", "c_double", "c_long_double",
+    "c_float_complex", "c_double_complex", "c_long_double_complex",
+    "c_bool", "c_char",
+    "c_null_char", "c_alert", "c_backspace", "c_form_feed",
+    "c_new_line", "c_carriage_return", "c_horizontal_tab",
+    "c_vertical_tab",
+    "c_ptr", "c_funptr", "c_null_ptr", "c_null_funptr",
+    "ieee_exceptions",
+    "ieee_arithmetic",
+    "ieee_features",
+    ## F2008 iso_fortran_env constants.
+    "character_kinds", "int8", "int16", "int32", "int64",
+    "integer_kinds", "iostat_inquire_internal_unit",
+    "logical_kinds", "real_kinds", "real32", "real64", "real128",
+    "lock_type", "atomic_int_kind", "atomic_logical_kind",
+    )) + r")\b", RE_FLAGS)
+
+F90_INT_RE = r"[-+]?[0-9]+"
+F90_FLOAT_RE = r"[-+]?([0-9]+\.[0-9]*|\.[0-9]+)"
+F90_NUMBER_RE = "(" + F90_INT_RE + "|" + F90_FLOAT_RE + ")"
+F90_FLOAT_EXP_RE = F90_NUMBER_RE + r"[eEdD]" + F90_NUMBER_RE
+F90_NUMBER_ALL_RE = "(" + F90_NUMBER_RE + "|" + F90_FLOAT_EXP_RE + ")"
+
+## F90_CONSTANTS_TYPES_RE = re.compile(r"\b" + F90_NUMBER_ALL_RE + "_(" + "|".join([a + r"\b" for a in (
+F90_CONSTANTS_TYPES_RE = re.compile(
+    r"(" + F90_NUMBER_ALL_RE + ")*_(" + "|".join((
+    ## F2003 iso_fortran_env constants.
+    ## F2003 iso_c_binding constants.
+    "c_int", "c_short", "c_long", "c_long_long", "c_signed_char",
+    "c_size_t",
+    "c_int8_t", "c_int16_t", "c_int32_t", "c_int64_t",
+    "c_int_least8_t", "c_int_least16_t", "c_int_least32_t",
+    "c_int_least64_t",
+    "c_int_fast8_t", "c_int_fast16_t", "c_int_fast32_t",
+    "c_int_fast64_t",
+    "c_intmax_t", "c_intptr_t",
+    "c_float", "c_double", "c_long_double",
+    "c_float_complex", "c_double_complex", "c_long_double_complex",
+    "c_bool", "c_char",
+    ## F2008 iso_fortran_env constants.
+    "character_kinds", "int8", "int16", "int32", "int64",
+    "integer_kinds",
+    "logical_kinds", "real_kinds", "real32", "real64", "real128",
+    "lock_type", "atomic_int_kind", "atomic_logical_kind",
+    )) + r")\b", RE_FLAGS)
+
+
 class F90Indenter(object):
     """
     Parses encapsulation of subunits / scopes line by line
@@ -649,6 +825,67 @@ def replace_relational_single_fline(f_line, cstyle):
     return new_line
 
 
+def replace_keywords_single_fline(f_line, case_dict):
+    """
+    format a single Fortran line - change case of keywords
+    """
+
+    new_line = f_line
+
+    # Collect words list
+    pos_prev = -1
+    pos = -1
+    line_parts = ['']
+    for pos, char in CharFilter(f_line):
+        if pos > pos_prev + 1: # skipped string
+            line_parts.append(f_line[pos_prev + 1:pos].strip()) # append string
+            line_parts.append('')
+
+        line_parts[-1] += char
+
+        pos_prev = pos
+
+    if pos + 1 < len(f_line):
+        line_parts.append(f_line[pos + 1:])
+
+    line_parts = [re.split('(\W)',a) for a in line_parts]  # problem, split "."
+    line_parts = [b for a in line_parts for b in a]
+
+    nbparts = len(line_parts)
+    for pos, part in enumerate(line_parts):
+        # exclude comments, strings:
+        if part.strip() and not (part == '\n' or STR_OPEN_RE.match(part)):
+            #print(len(line_parts),pos,repr(part))
+            if F90_KEYWORDS_RE.match(part):
+                part = case_dict['keywords'](part)
+            elif F90_PROCEDURES_RE.match(part):
+                ok = False
+                for pos2 in range(pos+1, nbparts):
+                    part2 = line_parts[pos2]
+                    if part2.strip() and not (part2 == '\n' or STR_OPEN_RE.match(part2)):
+                        ok = (part2 == '(')
+                        break
+                if ok:
+                    part = case_dict['procedures'](part)
+            elif F90_OPERATORS_RE.match(part):
+                pos1 = max(0, pos-1)
+                pos2 = min(pos+1, nbparts-1)
+                if line_parts[pos1] == line_parts[pos2] == '.':
+                    part = case_dict['operators'](part)
+            elif F90_HPF_KEYWORDS_RE.match(part):
+                part = case_dict['keywords'](part)
+            elif F90_CONSTANTS_RE.match(part):
+                part = case_dict['constants'](part)
+            elif F90_CONSTANTS_TYPES_RE.match(part):
+                part = case_dict['constants'](part)
+
+            line_parts[pos] = part
+
+    new_line = ''.join(line_parts)
+
+    return new_line
+
+
 def format_single_fline(f_line, whitespace, whitespace_dict, linebreak_pos,
                         ampersand_sep, filename, line_nr, auto_format=True):
     """
@@ -1007,6 +1244,7 @@ def reformat_inplace(filename, stdout=False, **kwargs):  # pragma: no cover
 
 
 def reformat_ffile(infile, outfile, impose_indent=True, indent_size=3, strict_indent=False, impose_whitespace=True,
+                   impose_case=False, case_dict={},
                    impose_replacements=False, cstyle=False, whitespace=2, whitespace_dict={}, llength=132,
                    strip_comments=False, orig_filename=None):
     """main method to be invoked for formatting a Fortran file."""
@@ -1094,6 +1332,9 @@ def reformat_ffile(infile, outfile, impose_indent=True, indent_size=3, strict_in
 
             if impose_replacements:
                 f_line = replace_relational_single_fline(f_line, cstyle)
+
+            if impose_case:
+                f_line = replace_keywords_single_fline(f_line, case_dict)
 
             if impose_whitespace:
                 lines = format_single_fline(
@@ -1478,6 +1719,8 @@ def run(argv=sys.argv):  # pragma: no cover
     parser.add_argument("--disable-whitespace", action='store_true', default=False, help="don't impose whitespace formatting")
     parser.add_argument("--enable-replacements", action='store_true', default=False, help="replace relational operators (e.g. '.lt.' <--> '<')")
     parser.add_argument("--c-relations", action='store_true', default=False, help="C-style relational operators ('<', '<=', ...)")
+    parser.add_argument("--enable-swap-case", action='store_true', default=False, help="replace character case formating for known keywords and constants")
+
     parser.add_argument("--strip-comments", action='store_true', default=False, help="strip whitespaces before comments")
     parser.add_argument("-s", "--stdout", action='store_true', default=False,
                         help="Write to stdout instead of formatting inplace")
@@ -1509,6 +1752,14 @@ def run(argv=sys.argv):  # pragma: no cover
     ws_dict['print'] = args.whitespace_print
     ws_dict['type'] = args.whitespace_type
     ws_dict['intrinsics'] = args.whitespace_intrinsics
+
+    # build swap case dictionary, could add option to select case
+    case_dict = {
+        'keywords' : unicode.lower,
+        'procedures' : unicode.lower,
+        'operators' : unicode.lower,
+        'constants' : unicode.upper,
+        }
 
     # support legacy input:
     if 'stdin' in args.path and not os.path.isfile('stdin'):
@@ -1561,6 +1812,8 @@ def run(argv=sys.argv):  # pragma: no cover
                                  impose_whitespace=not args.disable_whitespace,
                                  impose_replacements=args.enable_replacements,
                                  cstyle=args.c_relations,
+                                 impose_case=args.enable_swap_case,
+                                 case_dict=case_dict,
                                  whitespace=args.whitespace,
                                  whitespace_dict=ws_dict,
                                  llength=1024 if args.line_length == 0 else args.line_length,

--- a/fprettify/tests/__init__.py
+++ b/fprettify/tests/__init__.py
@@ -375,8 +375,8 @@ class FPrettifyTestCase(unittest.TestCase):
                      "if (min .ne. max .and. min .ne. thres)",
                      "if (min .ge. max .and. min .ge. thres)",
                      "if (min .le. max .and. min .le. thres)",
-                    "'==== heading",
-                    "if (vtk%my_rank .eq. 0) write (vtk%filehandle_par, '(\"<DataArray",
+                     "'==== heading",
+                     "if (vtk%my_rank .eq. 0) write (vtk%filehandle_par, '(\"<DataArray",
                      "'(\"</Collection>\","]
         c_outstring = ["if (min < max .and. min < thres)",
                      "if (min > max .and. min > thres)",
@@ -384,13 +384,61 @@ class FPrettifyTestCase(unittest.TestCase):
                      "if (min /= max .and. min /= thres)",
                      "if (min >= max .and. min >= thres)",
                      "if (min <= max .and. min <= thres)",
-                    "'==== heading",
-                    "if (vtk%my_rank == 0) write (vtk%filehandle_par, '(\"<DataArray",
+                     "'==== heading",
+                     "if (vtk%my_rank == 0) write (vtk%filehandle_par, '(\"<DataArray",
                      "'(\"</Collection>\","]
 
         for i in range(0, len(instring)):
             self.assert_fprettify_result(['--enable-replacements', '--c-relations'], instring[i], c_outstring[i])
             self.assert_fprettify_result(['--enable-replacements'], instring[i], f_outstring[i])
+
+    def test_swap_case(self):
+        """test relacement of keyword character case"""
+        instring = (
+            "MODULE exAmple",
+            "INTEGER,   PARAMETER :: SELECTED_REAL_KIND = 1*2",
+            "INTEGER,   PARAMETER :: dp1 = SELECTED_REAL_KIND ( 15 , 307)",
+            'CHARACTER(LEN=*), PARAMETER :: a = "INTEGER,   PARAMETER" // "b"',
+            "CHARACTER(LEN=*), PARAMETER :: a = 'INTEGER,   PARAMETER' // 'b'",
+            "INTEGER(kind=int64), PARAMETER :: l64 = 2_int64",
+            "REAL(kind=real64), PARAMETER :: r64a = 2._real64",
+            "REAL(kind=real64), PARAMETER :: r64b = 2.0_real64",
+            "REAL(kind=real64), PARAMETER :: r64c = .0_real64",
+            "REAL(kind=real64), PARAMETER :: r64a = 2.e3_real64",
+            "REAL(kind=real64), PARAMETER :: r64b = 2.0e3_real64",
+            "REAL(kind=real64), PARAMETER :: r64c = .0e3_real64",
+            "REAL, PARAMETER :: r32 = 2.e3",
+            "REAL, PARAMETER :: r32 = 2.0d3",
+            "REAL, PARAMETER :: r32 = .2e3",
+            "USE iso_fortran_env, only: int64",
+            "INTEGER, INTENT(IN) :: r, i, j, k",
+            "IF (l.EQ.2) l=MAX  (l64, 2_int64)",
+            "PURE SUBROUTINE mypure()"
+            )
+        outstring = (
+            "module exAmple",
+            "integer, parameter :: SELECTED_REAL_KIND = 1*2",
+            "integer, parameter :: dp1 = selected_real_kind(15, 307)",
+            'character(LEN=*), parameter :: a = "INTEGER,   PARAMETER"//"b"',
+            "character(LEN=*), parameter :: a = 'INTEGER,   PARAMETER'//'b'",
+            "integer(kind=INT64), parameter :: l64 = 2_INT64",
+            "real(kind=REAL64), parameter :: r64a = 2._REAL64",
+            "real(kind=REAL64), parameter :: r64b = 2.0_REAL64",
+            "real(kind=REAL64), parameter :: r64c = .0_REAL64",
+            "real(kind=REAL64), parameter :: r64a = 2.E3_REAL64",
+            "real(kind=REAL64), parameter :: r64b = 2.0E3_REAL64",
+            "real(kind=REAL64), parameter :: r64c = .0E3_REAL64",
+            "real, parameter :: r32 = 2.E3",
+            "real, parameter :: r32 = 2.0D3",
+            "real, parameter :: r32 = .2E3",
+            "use ISO_FORTRAN_ENV, only: INT64",
+            "integer, intent(IN) :: r, i, j, k",
+            "if (l .eq. 2) l = max(l64, 2_INT64)",
+            "pure subroutine mypure()"
+            )
+        for i in range(len(instring)):
+            self.assert_fprettify_result(['--enable-swap-case'],
+                                         instring[i], outstring[i])
 
     def test_do(self):
         """test correct parsing of do statement"""


### PR DESCRIPTION
This patch allow changing character case of keywords (up to Fortran 2008) and some known constants (list taken from emacs' F90 mode).
For now keywords are lowercased and constants are uppercased.
It would be easy to add options so one can choose its preferred case.
I'll do it if there is a need (didn't want to crowd the option list too much).
