### PR TITLE
Fix multi line --enable-replacements --c-relations

### DIFF
--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -628,19 +628,19 @@ def replace_relational_single_fline(f_line, cstyle):
             if not STR_OPEN_RE.match(part):
                 # also exclude / if we see a namelist and data statement
                 if cstyle:
-                    part = re.sub(r"\s*\.LT\.\s*", "<",  part, flags=RE_FLAGS)
-                    part = re.sub(r"\s*\.LE\.\s*", "<=", part, flags=RE_FLAGS)
-                    part = re.sub(r"\s*\.GT\.\s*", ">",  part, flags=RE_FLAGS)
-                    part = re.sub(r"\s*\.GE\.\s*", ">=", part, flags=RE_FLAGS)
-                    part = re.sub(r"\s*\.EQ\.\s*", "==", part, flags=RE_FLAGS)
-                    part = re.sub(r"\s*\.NE\.\s*", "/=", part, flags=RE_FLAGS)
+                    part = re.sub(r"\.LT\.", "<   ", part, flags=RE_FLAGS)
+                    part = re.sub(r"\.LE\.", "<=  ", part, flags=RE_FLAGS)
+                    part = re.sub(r"\.GT\.", ">   ", part, flags=RE_FLAGS)
+                    part = re.sub(r"\.GE\.", ">=  ", part, flags=RE_FLAGS)
+                    part = re.sub(r"\.EQ\.", "==  ", part, flags=RE_FLAGS)
+                    part = re.sub(r"\.NE\.", "/=  ", part, flags=RE_FLAGS)
                 else:
-                    part = re.sub(r"\s*<=\s*",  ".le.", part, flags=RE_FLAGS)
-                    part = re.sub(r"\s*<\s*",   ".lt.", part, flags=RE_FLAGS)
-                    part = re.sub(r"\s*>=\s*",  ".ge.", part, flags=RE_FLAGS)
-                    part = re.sub(r"\s*>\s*",   ".gt.", part, flags=RE_FLAGS)
-                    part = re.sub(r"\s*==\s*",  ".eq.", part, flags=RE_FLAGS)
-                    part = re.sub(r"\s*\/=\s*", ".ne.", part, flags=RE_FLAGS)
+                    part = re.sub(r"<=",  ".le.", part, flags=RE_FLAGS)
+                    part = re.sub(r"<",   ".lt.", part, flags=RE_FLAGS)
+                    part = re.sub(r">=",  ".ge.", part, flags=RE_FLAGS)
+                    part = re.sub(r">",   ".gt.", part, flags=RE_FLAGS)
+                    part = re.sub(r"==",  ".eq.", part, flags=RE_FLAGS)
+                    part = re.sub(r"\/=", ".ne.", part, flags=RE_FLAGS)
 
             line_parts[pos] = part
 

--- a/fprettify/tests/__init__.py
+++ b/fprettify/tests/__init__.py
@@ -368,7 +368,8 @@ class FPrettifyTestCase(unittest.TestCase):
                     "if( min <= max .and. min .le. thres)",
                     "'==== heading",
                     "if (vtk%my_rank .eq. 0) write (vtk%filehandle_par, '(\"<DataArray",
-                    "'(\"</Collection>\","]
+                    "'(\"</Collection>\",",
+                    "if (abc(1) .lt. -bca .or. &\n qwe .gt. ewq) then"]
         f_outstring = ["if (min .lt. max .and. min .lt. thres)",
                      "if (min .gt. max .and. min .gt. thres)",
                      "if (min .eq. max .and. min .eq. thres)",
@@ -377,7 +378,8 @@ class FPrettifyTestCase(unittest.TestCase):
                      "if (min .le. max .and. min .le. thres)",
                     "'==== heading",
                     "if (vtk%my_rank .eq. 0) write (vtk%filehandle_par, '(\"<DataArray",
-                     "'(\"</Collection>\","]
+                    "'(\"</Collection>\",",
+                    "if (abc(1) .lt. -bca .or. &\n    qwe .gt. ewq) then"]
         c_outstring = ["if (min < max .and. min < thres)",
                      "if (min > max .and. min > thres)",
                      "if (min == max .and. min == thres)",
@@ -386,8 +388,8 @@ class FPrettifyTestCase(unittest.TestCase):
                      "if (min <= max .and. min <= thres)",
                     "'==== heading",
                     "if (vtk%my_rank == 0) write (vtk%filehandle_par, '(\"<DataArray",
-                     "'(\"</Collection>\","]
-
+                     "'(\"</Collection>\",",
+                    "if (abc(1) < -bca .or. &\n    qwe > ewq) then"]
         for i in range(0, len(instring)):
             self.assert_fprettify_result(['--enable-replacements', '--c-relations'], instring[i], c_outstring[i])
             self.assert_fprettify_result(['--enable-replacements'], instring[i], f_outstring[i])


### PR DESCRIPTION
Here is a patch for the issue with relationals replacement to C-style when there is a line continuation (&).
Issue is described in: https://github.com/pseewald/fprettify/issues/47
