### PR TITLE
Recommit support for submodules.

### DIFF
--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -138,6 +138,10 @@ SUBR_RE = re.compile(
 ENDSUBR_RE = re.compile(
     SOL_STR + r"END\s*SUBROUTINE(\s+\w+)?" + EOL_STR, RE_FLAGS)
 
+# add support for submodules
+SMOD_RE = re.compile(SOL_STR + r"SUBMODULE\s*\(\w+\)\s+\w+" + EOL_STR, RE_FLAGS)
+ENDSMOD_RE = re.compile(SOL_STR + r"END\s*SUBMODULE(\s+\w+)?" + EOL_STR, RE_FLAGS)
+
 FCT_RE = re.compile(
     r"^([^\"']* )?FUNCTION\s+\w+\s*(\(.*\))?(\s*RESULT\s*\(\w+\))?" + EOL_STR,
     RE_FLAGS)
@@ -218,10 +222,12 @@ NO_ALIGN_RE = re.compile(SOL_STR + r"&\s*[^\s*]+")
 # combine regex that define subunits
 NEW_SCOPE_RE = [IF_RE, DO_RE, SELCASE_RE, SUBR_RE,
                 FCT_RE, MOD_RE, PROG_RE, INTERFACE_RE, TYPE_RE, ENUM_RE, ASSOCIATE_RE, None, BLK_RE]
+                FCT_RE, MOD_RE, SMOD_RE, PROG_RE, INTERFACE_RE, TYPE_RE, ENUM_RE, ASSOCIATE_RE, None, BLK_RE]
 CONTINUE_SCOPE_RE = [ELSE_RE, None, CASE_RE, CONTAINS_RE,
                      CONTAINS_RE, CONTAINS_RE, CONTAINS_RE, None, CONTAINS_RE, None, None, None, None]
 END_SCOPE_RE = [ENDIF_RE, ENDDO_RE, ENDSEL_RE, ENDSUBR_RE,
                 ENDFCT_RE, ENDMOD_RE, ENDPROG_RE, ENDINTERFACE_RE, ENDTYPE_RE, ENDENUM_RE, ENDASSOCIATE_RE, ENDANY_RE, ENDBLK_RE]
+                ENDFCT_RE, ENDMOD_RE, ENDSMOD_RE, ENDPROG_RE, ENDINTERFACE_RE, ENDTYPE_RE, ENDENUM_RE, ENDASSOCIATE_RE, ENDANY_RE, ENDBLK_RE]
 
 # match namelist names
 NML_RE = re.compile(r"(/\w+/)", RE_FLAGS)


### PR DESCRIPTION
Hi, it took me a while to figure out how to revert to the previous commit...
Hopefully it's good now. Just to be clear, this commit is for the support of submodules.
The indentation should look like something as follows:

```Fortran
submodule (module_1) submodule_1
    ! There might or might not be a space
    ! between 'submodule' and '(module_1)'
    ! but there usually is a space between 
    ! '(module_1)' and 'submodule_1'
    real, parameter :: submodule_param = 1.0
contains
    module subroutine sub_1(a, b)
        ! An interface in the main module is required
        real, intent(in) :: a 
        real, intent(out) :: b 
    end subroutine sub_1

    subroutine sub_2(a, b)
        ! Cannot be used by other submodules
        real, intent(in) :: a 
        real, intent(out) :: b 
    end subroutine sub_2
end submodule submodule_1
```

Best,
Han