### PR TITLE
Add support for cmd line config file args '-c' & parent dir config files

### DIFF
--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -1452,80 +1452,101 @@ def run(argv=sys.argv):  # pragma: no cover
         else:
             return None
 
+    def get_config_file_list(filename):
+        """helper function to create list of config files found in parent directories"""
+        config_file_list = []
+        dir = os.path.dirname(filename)
+        while True:
+            config_file = os.path.join(dir, '.fprettify.rc')
+            if os.path.isfile(config_file):
+                config_file_list.insert(0, config_file)
+            parent=os.path.dirname(dir)
+            if parent == dir:
+                break
+            dir = parent
+        return config_file_list
+
     arguments = {'prog': argv[0],
                  'description': 'Auto-format modern Fortran source files.',
                  'formatter_class': argparse.ArgumentDefaultsHelpFormatter}
 
     if argparse.__name__ == "configargparse":
-        arguments['default_config_files'] = ['~/.fprettify.rc', '.fprettify.rc']
+        arguments['args_for_setting_config_path'] = ['-c', '--config-file']
+        arguments['description'] = arguments['description'] + " Config files ('.fprettify.rc') in the home (~) directory and any such files located in parent directories of the input file will be used. When the standard input is used, the search is started from the current directory."
 
-    parser = argparse.ArgumentParser(**arguments)
+    def get_arg_parser(args):
+        """helper function to create the parser object"""
+        parser = argparse.ArgumentParser(**args)
 
-    parser.add_argument("-i", "--indent", type=int, default=3,
-                        help="relative indentation width")
-    parser.add_argument("-l", "--line-length", type=int, default=132,
-                        help="column after which a line should end, viz. -ffree-line-length-n for GCC")
-    parser.add_argument("-w", "--whitespace", type=int,
-                        choices=range(0, 5), default=2, help="Presets for the amount of whitespace - "
-                                                             "   0: minimal whitespace"
-                                                             " | 1: operators (except arithmetic), print/read"
-                                                             " | 2: operators, print/read, plus/minus"
-                                                             " | 3: operators, print/read, plus/minus, muliply/divide"
-                                                             " | 4: operators, print/read, plus/minus, muliply/divide, type component selector")
-    parser.add_argument("--whitespace-comma", type=str2bool, nargs="?", default="None", const=True,
-            help="boolean, en-/disable whitespace for comma/semicolons")
-    parser.add_argument("--whitespace-assignment", type=str2bool, nargs="?", default="None", const=True,
-            help="boolean, en-/disable whitespace for assignments")
-    parser.add_argument("--whitespace-relational", type=str2bool, nargs="?", default="None", const=True,
-            help="boolean, en-/disable whitespace for relational operators")
-    parser.add_argument("--whitespace-logical", type=str2bool, nargs="?", default="None", const=True,
-            help="boolean, en-/disable whitespace for logical operators")
-    parser.add_argument("--whitespace-plusminus", type=str2bool, nargs="?", default="None", const=True,
-            help="boolean, en-/disable whitespace for plus/minus arithmetic")
-    parser.add_argument("--whitespace-multdiv", type=str2bool, nargs="?", default="None", const=True,
-            help="boolean, en-/disable whitespace for multiply/divide arithmetic")
-    parser.add_argument("--whitespace-print", type=str2bool, nargs="?", default="None", const=True,
-            help="boolean, en-/disable whitespace for print/read statements")
-    parser.add_argument("--whitespace-type", type=str2bool, nargs="?", default="None", const=True,
-            help="boolean, en-/disable whitespace for select type components")
-    parser.add_argument("--whitespace-intrinsics", type=str2bool, nargs="?", default="None", const=True,
-            help="boolean, en-/disable whitespace for intrinsics like if/write/close")
-    parser.add_argument("--strict-indent", action='store_true', default=False, help="strictly impose indentation even for nested loops")
-    parser.add_argument("--disable-indent", action='store_true', default=False, help="don't impose indentation")
-    parser.add_argument("--disable-whitespace", action='store_true', default=False, help="don't impose whitespace formatting")
-    parser.add_argument("--enable-replacements", action='store_true', default=False, help="replace relational operators (e.g. '.lt.' <--> '<')")
-    parser.add_argument("--c-relations", action='store_true', default=False, help="C-style relational operators ('<', '<=', ...)")
-    parser.add_argument("--strip-comments", action='store_true', default=False, help="strip whitespaces before comments")
-    parser.add_argument("-s", "--stdout", action='store_true', default=False,
-                        help="Write to stdout instead of formatting inplace")
+        parser.add_argument("-i", "--indent", type=int, default=3,
+                            help="relative indentation width")
+        parser.add_argument("-l", "--line-length", type=int, default=132,
+                            help="column after which a line should end, viz. -ffree-line-length-n for GCC")
+        parser.add_argument("-w", "--whitespace", type=int,
+                            choices=range(0, 5), default=2, help="Presets for the amount of whitespace - "
+                                                                 "   0: minimal whitespace"
+                                                                 " | 1: operators (except arithmetic), print/read"
+                                                                 " | 2: operators, print/read, plus/minus"
+                                                                 " | 3: operators, print/read, plus/minus, muliply/divide"
+                                                                 " | 4: operators, print/read, plus/minus, muliply/divide, type component selector")
+        parser.add_argument("--whitespace-comma", type=str2bool, nargs="?", default="None", const=True,
+                            help="boolean, en-/disable whitespace for comma/semicolons")
+        parser.add_argument("--whitespace-assignment", type=str2bool, nargs="?", default="None", const=True,
+                            help="boolean, en-/disable whitespace for assignments")
+        parser.add_argument("--whitespace-relational", type=str2bool, nargs="?", default="None", const=True,
+                            help="boolean, en-/disable whitespace for relational operators")
+        parser.add_argument("--whitespace-logical", type=str2bool, nargs="?", default="None", const=True,
+                            help="boolean, en-/disable whitespace for logical operators")
+        parser.add_argument("--whitespace-plusminus", type=str2bool, nargs="?", default="None", const=True,
+                            help="boolean, en-/disable whitespace for plus/minus arithmetic")
+        parser.add_argument("--whitespace-multdiv", type=str2bool, nargs="?", default="None", const=True,
+                            help="boolean, en-/disable whitespace for multiply/divide arithmetic")
+        parser.add_argument("--whitespace-print", type=str2bool, nargs="?", default="None", const=True,
+                            help="boolean, en-/disable whitespace for print/read statements")
+        parser.add_argument("--whitespace-type", type=str2bool, nargs="?", default="None", const=True,
+                            help="boolean, en-/disable whitespace for select type components")
+        parser.add_argument("--whitespace-intrinsics", type=str2bool, nargs="?", default="None", const=True,
+                            help="boolean, en-/disable whitespace for intrinsics like if/write/close")
+        parser.add_argument("--strict-indent", action='store_true', default=False, help="strictly impose indentation even for nested loops")
+        parser.add_argument("--disable-indent", action='store_true', default=False, help="don't impose indentation")
+        parser.add_argument("--disable-whitespace", action='store_true', default=False, help="don't impose whitespace formatting")
+        parser.add_argument("--enable-replacements", action='store_true', default=False, help="replace relational operators (e.g. '.lt.' <--> '<')")
+        parser.add_argument("--c-relations", action='store_true', default=False, help="C-style relational operators ('<', '<=', ...)")
+        parser.add_argument("--strip-comments", action='store_true', default=False, help="strip whitespaces before comments")
+        parser.add_argument("-s", "--stdout", action='store_true', default=False,
+                            help="Write to stdout instead of formatting inplace")
 
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument("-S", "--silent", "--no-report-errors", action='store_true',
-                       default=False, help="Don't write any errors or warnings to stderr")
-    group.add_argument("-D", "--debug", action='store_true',
-                       default=False, help=argparse.SUPPRESS)
-    parser.add_argument("path", type=str, nargs='*',
-                        help="Paths to files to be formatted inplace. If no paths are given, stdin (-) is used by default. Path can be a directory if --recursive is used.", default=['-'])
-    parser.add_argument('-r', '--recursive', action='store_true',
-                        default=False, help="Recursively auto-format all Fortran files in subdirectories of specified path; recognized filename extensions: {}". format(", ".join(FORTRAN_EXTENSIONS)))
-    parser.add_argument('-f', '--fortran', type=str, action='append', default=[],
-                        help="Overrides default fortran extensions recognized by --recursive. Repeat this option to specify more than one extension.")
-    parser.add_argument('--version', action='version',
-                        version='%(prog)s 0.3.6')
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument("-S", "--silent", "--no-report-errors", action='store_true',
+                           default=False, help="Don't write any errors or warnings to stderr")
+        group.add_argument("-D", "--debug", action='store_true',
+                           default=False, help=argparse.SUPPRESS)
+        parser.add_argument("path", type=str, nargs='*',
+                            help="Paths to files to be formatted inplace. If no paths are given, stdin (-) is used by default. Path can be a directory if --recursive is used.", default=['-'])
+        parser.add_argument('-r', '--recursive', action='store_true',
+                            default=False, help="Recursively auto-format all Fortran files in subdirectories of specified path; recognized filename extensions: {}". format(", ".join(FORTRAN_EXTENSIONS)))
+        parser.add_argument('-f', '--fortran', type=str, action='append', default=[],
+                            help="Overrides default fortran extensions recognized by --recursive. Repeat this option to specify more than one extension.")
+        parser.add_argument('--version', action='version',
+                            version='%(prog)s 0.3.6')
+        return parser
 
+    parser = get_arg_parser(arguments)
     args = parser.parse_args(argv[1:])
 
-    # build whitespace dictionary
-    ws_dict = {}
-    ws_dict['comma'] = args.whitespace_comma
-    ws_dict['assignments'] = args.whitespace_assignment
-    ws_dict['relational'] = args.whitespace_relational
-    ws_dict['logical'] = args.whitespace_logical
-    ws_dict['plusminus'] = args.whitespace_plusminus
-    ws_dict['multdiv'] = args.whitespace_multdiv
-    ws_dict['print'] = args.whitespace_print
-    ws_dict['type'] = args.whitespace_type
-    ws_dict['intrinsics'] = args.whitespace_intrinsics
+    def build_ws_dict(args):
+        """helper function to build whitespace dictionary"""
+        ws_dict = {}
+        ws_dict['comma'] = args.whitespace_comma
+        ws_dict['assignments'] = args.whitespace_assignment
+        ws_dict['relational'] = args.whitespace_relational
+        ws_dict['logical'] = args.whitespace_logical
+        ws_dict['plusminus'] = args.whitespace_plusminus
+        ws_dict['multdiv'] = args.whitespace_multdiv
+        ws_dict['print'] = args.whitespace_print
+        ws_dict['type'] = args.whitespace_type
+        ws_dict['intrinsics'] = args.whitespace_intrinsics
+        return ws_dict
 
     # support legacy input:
     if 'stdin' in args.path and not os.path.isfile('stdin'):
@@ -1558,9 +1579,17 @@ def run(argv=sys.argv):  # pragma: no cover
                     filenames.append(ffile)
 
         for filename in filenames:
-            stdout = args.stdout or directory == '-'
+            # reparse arguments using the file's list of config files
+            filearguments = arguments
+            if argparse.__name__ == "configargparse":
+                filearguments['default_config_files'] = ['~/.fprettify.rc'] + get_config_file_list(os.path.abspath(filename) if filename != '-' else os.getcwd())
+            file_argparser = get_arg_parser(filearguments)
+            file_args = file_argparser.parse_args(argv[1:])
+            ws_dict = build_ws_dict(file_args)
 
-            if args.debug:
+            stdout = file_args.stdout or directory == '-'
+
+            if file_args.debug:
                 level = logging.DEBUG
             elif args.silent:
                 level = logging.CRITICAL
@@ -1572,15 +1601,15 @@ def run(argv=sys.argv):  # pragma: no cover
             try:
                 reformat_inplace(filename,
                                  stdout=stdout,
-                                 impose_indent=not args.disable_indent,
-                                 indent_size=args.indent,
-                                 strict_indent=args.strict_indent,
-                                 impose_whitespace=not args.disable_whitespace,
-                                 impose_replacements=args.enable_replacements,
-                                 cstyle=args.c_relations,
-                                 whitespace=args.whitespace,
+                                 impose_indent=not file_args.disable_indent,
+                                 indent_size=file_args.indent,
+                                 strict_indent=file_args.strict_indent,
+                                 impose_whitespace=not file_args.disable_whitespace,
+                                 impose_replacements=file_args.enable_replacements,
+                                 cstyle=file_args.c_relations,
+                                 whitespace=file_args.whitespace,
                                  whitespace_dict=ws_dict,
-                                 llength=1024 if args.line_length == 0 else args.line_length,
-                                 strip_comments=args.strip_comments)
+                                 llength=1024 if file_args.line_length == 0 else file_args.line_length,
+                                 strip_comments=file_args.strip_comments)
             except FprettifyException as e:
                 log_exception(e, "Fatal error occured")


### PR DESCRIPTION
* Support '-c' and '--config-file' args to specify config files on
  command line.

* Add feature (in spirit of clang-format) to use any config files that
  are found in the file's directory and each parent directory of the file.

Closes #77