### PR TITLE
Add a diff-only option

### DIFF
--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -1610,7 +1610,7 @@ def run(argv=sys.argv):  # pragma: no cover
             ws_dict = build_ws_dict(file_args)
 
             stdout = file_args.stdout or directory == '-'
-            diff=file_args.diff
+            diffonly=file_args.diff
 
             if file_args.debug:
                 level = logging.DEBUG
@@ -1624,7 +1624,7 @@ def run(argv=sys.argv):  # pragma: no cover
             try:
                 reformat_inplace(filename,
                                  stdout=stdout,
-                                 diffonly=diff,
+                                 diffonly=diffonly,
                                  impose_indent=not file_args.disable_indent,
                                  indent_size=file_args.indent,
                                  strict_indent=file_args.strict_indent,

--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -981,7 +981,9 @@ def split_reformatted_line(line_orig, linebreak_pos_orig, ampersand_sep, line, f
     return lines_split
 
 
-def diff(a: str, b: str, a_name: str, b_name: str) -> str:
+def diff(a, b, a_name, b_name):
+    # type: (str, str, str, str) -> str
+
     """Return a unified diff string between strings `a` and `b`."""
     import difflib
 


### PR DESCRIPTION
This PR adds a command-line option to print diffs of the file(s) to standard output instead of changing the files in-place.