### PR TITLE
New option --exclude to exclude files matching a specified pattern

### DIFF
--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -1551,7 +1551,7 @@ def run(argv=sys.argv):  # pragma: no cover
                             default=False, help="Recursively auto-format all Fortran files in subdirectories of specified path; recognized filename extensions: {}". format(", ".join(FORTRAN_EXTENSIONS)))
         parser.add_argument('-e', '--exclude', action='append',
                             default=[], type=str,
-                            help="File or directory patterns to be excluded when searching for Fortran filesx to format")
+                            help="File or directory patterns to be excluded when searching for Fortran files to format")
         parser.add_argument('-f', '--fortran', type=str, action='append', default=[],
                             help="Overrides default fortran extensions recognized by --recursive. Repeat this option to specify more than one extension.")
         parser.add_argument('--version', action='version',

--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -1549,8 +1549,9 @@ def run(argv=sys.argv):  # pragma: no cover
                             help="Paths to files to be formatted inplace. If no paths are given, stdin (-) is used by default. Path can be a directory if --recursive is used.", default=['-'])
         parser.add_argument('-r', '--recursive', action='store_true',
                             default=False, help="Recursively auto-format all Fortran files in subdirectories of specified path; recognized filename extensions: {}". format(", ".join(FORTRAN_EXTENSIONS)))
-        parser.add_argument('-e', '--exclude', action='extend',
-                            default=[], nargs="+", type=str, help="File or directory patterns to be excluded when searching for Fortran files to format")
+        parser.add_argument('-e', '--exclude', action='append',
+                            default=[], type=str,
+                            help="File or directory patterns to be excluded when searching for Fortran filesx to format")
         parser.add_argument('-f', '--fortran', type=str, action='append', default=[],
                             help="Overrides default fortran extensions recognized by --recursive. Repeat this option to specify more than one extension.")
         parser.add_argument('--version', action='version',


### PR DESCRIPTION
This adds the option --exclude which allows the user to specify one or more patterns of file or directory names that should be excluded when searching for files to format.