### PR TITLE
Enable CI via GH actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Build package
+        run: pipx run build
+
+      - name: Publish to Test PyPi
+        if: ${{ startsWith(github.ref, 'refs/tags') }}
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Publish to PyPi
+        if: ${{ startsWith(github.ref, 'refs/tags') }}
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,10 +70,12 @@ jobs:
         run: |
           coverage run --source=fprettify setup.py test
 
-      # - name: Coverage upload
-      #   run: coveralls
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Coverage upload
+        run: coveralls --service=github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: ${{ matrix.python }}
+          COVERALLS_PARALLEL: true
 
   pip:
     needs:
@@ -100,7 +102,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install dependencies
-        run: pip install -U -r requirements.txt coveralls
+        run: pip install -r requirements.txt coveralls
 
       - name: Install project
         run: pip install .
@@ -109,7 +111,28 @@ jobs:
         run: |
           coverage run --source=fprettify setup.py test
 
-      # - name: Coverage upload
-      #   run: coveralls
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Coverage upload
+        run: coveralls --service=github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: ${{ matrix.python }}
+          COVERALLS_PARALLEL: true
+
+  coverage:
+    needs:
+      - pip
+      - conda
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install coveralls
+
+      - name: Coverage upload
+        run: coveralls --service=github --finish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,115 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 3"
+  workflow_dispatch:
+
+jobs:
+  resources:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Create resource cache
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: ./fortran_tests/before/*/
+          key: resources-${{ github.event_name }}
+
+      - name: Prepare tests (default)
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        run: |
+          .travis/prep_regular.sh
+
+      - name: Prepare tests (schedule)
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name == 'schedule' }}
+        run: |
+          .travis/prep_cron.sh
+
+  conda:
+    needs:
+      - resources
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python: ["3.7", "3.8", "3.9", "3.10"]
+
+    defaults:
+      run:
+        shell: "bash -l {0}"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Load resources
+        uses: actions/cache@v3
+        with:
+          path: ./fortran_tests/before/*/
+          key: resources-${{ github.event_name }}
+
+      - name: Install dependencies
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: environment.yml
+          extra-specs: |
+            python=${{ matrix.python }}
+            coveralls
+
+      - name: Install project
+        run: pip install .
+
+      - name: Run tests
+        run: |
+          coverage run --source=fprettify setup.py test
+
+      # - name: Coverage upload
+      #   run: coveralls
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  pip:
+    needs:
+      - resources
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python: ["3.5", "3.6"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Load resources
+        uses: actions/cache@v3
+        with:
+          path: ./fortran_tests/before/*/
+          key: resources-${{ github.event_name }}
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install dependencies
+        run: pip install -U -r requirements.txt coveralls
+
+      - name: Install project
+        run: pip install .
+
+      - name: Run tests
+        run: |
+          coverage run --source=fprettify setup.py test
+
+      # - name: Coverage upload
+      #   run: coveralls
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,5 @@
+name: devel
+channels:
+  - conda-forge
+dependencies:
+  - configargparse


### PR DESCRIPTION
- Python 3.5 / 3.6 using preinstalled Python versions on runner
- Python 3.7 to 3.10 using conda-forge Python

TODO

- [x] coverage upload to coveralls
- [x] pypi upload (different workflow?)

Closes pseewald/fprettify#128