### PR TITLE
Swap into using pyproject.toml and setup.cfg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,10 @@ jobs:
           python-version: "3.x"
 
       - name: Build package
-        run: pipx run build
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+          python -m build
 
       - name: Publish to Test PyPi
         if: ${{ startsWith(github.ref, 'refs/tags') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,11 +101,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install dependencies
-        run: pip install -r requirements.txt coveralls
-
-      - name: Install project
-        run: pip install .
+      - name: Install project & dependencies
+        run: pip install .[dev]
 
       - name: Run tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ tags
 
 # setuptools_scm autogeneated version
 _version.py
+
+# fortran temporary test files
+fortran_tests/

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ ENV/
 
 # ctags
 tags
+
+# setuptools_scm autogeneated version
+_version.py

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/pseewald/fprettify/actions/workflows/test.yml/badge.svg)](https://github.com/pseewald/fprettify/actions/workflows/test.yml)
 [![Coverage Status](https://coveralls.io/repos/github/pseewald/fprettify/badge.svg?branch=master)](https://coveralls.io/github/pseewald/fprettify?branch=master)
-[![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
+![PyPI - License](https://img.shields.io/pypi/l/fprettify)
 ![PyPI](https://img.shields.io/pypi/v/fprettify)
 
 fprettify is an auto-formatter for modern Fortran code that imposes strict whitespace formatting, written in Python.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,40 @@
 # fprettify
 
-[![Build Status](https://travis-ci.com/pseewald/fprettify.svg?branch=master)](https://travis-ci.com/pseewald/fprettify) [![Coverage Status](https://coveralls.io/repos/github/pseewald/fprettify/badge.svg?branch=master)](https://coveralls.io/github/pseewald/fprettify?branch=master) [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0) [![PyPI version](https://badge.fury.io/py/fprettify.svg)](https://badge.fury.io/py/fprettify)
+[![CI](https://github.com/pseewald/fprettify/actions/workflows/test.yml/badge.svg)](https://github.com/pseewald/fprettify/actions/workflows/test.yml)
+[![Coverage Status](https://coveralls.io/repos/github/pseewald/fprettify/badge.svg?branch=master)](https://coveralls.io/github/pseewald/fprettify?branch=master)
+[![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
+![PyPI](https://img.shields.io/pypi/v/fprettify)
 
 fprettify is an auto-formatter for modern Fortran code that imposes strict whitespace formatting, written in Python.
 
 **NOTE:** I'm looking for help to maintain this repository, see [#127](https://github.com/pseewald/fprettify/issues/127).
 
-
 ## Features
 
-* Auto-indentation.
-* Line continuations are aligned with the previous opening delimiter `(`, `[` or `(/` or with an assignment operator `=` or `=>`. If none of the above is present, a default hanging indent is applied.
-* Consistent amount of whitespace around operators and delimiters.
-* Removal of extraneous whitespace and consecutive blank lines.
-* Change letter case (upper case / lower case conventions) of intrinsics
-* Tested for editor integration.
-* By default, fprettify causes whitespace changes only and thus preserves revision history.
-* fprettify can handle cpp and [fypp](https://github.com/aradi/fypp) preprocessor directives.
-
+- Auto-indentation.
+- Line continuations are aligned with the previous opening delimiter `(`, `[` or `(/` or with an assignment operator `=` or `=>`. If none of the above is present, a default hanging indent is applied.
+- Consistent amount of whitespace around operators and delimiters.
+- Removal of extraneous whitespace and consecutive blank lines.
+- Change letter case (upper case / lower case conventions) of intrinsics
+- Tested for editor integration.
+- By default, fprettify causes whitespace changes only and thus preserves revision history.
+- fprettify can handle cpp and [fypp](https://github.com/aradi/fypp) preprocessor directives.
 
 ## Limitations
 
-* Works only for modern Fortran (Fortran 90 upwards).
-* Feature missing? Please create an issue.
-
+- Works only for modern Fortran (Fortran 90 upwards).
+- Feature missing? Please create an issue.
 
 ## Requirements
 
-* Python 3 (Python 2.7 no longer supported)
-* [ConfigArgParse](https://pypi.org/project/ConfigArgParse): optional, enables use of config file
-
+- Python 3 (Python 2.7 no longer supported)
+- [ConfigArgParse](https://pypi.org/project/ConfigArgParse): optional, enables use of config file
 
 ## Examples
 
 Compare `examples/*before.f90` (original Fortran files) with `examples/*after.f90` (reformatted Fortran files) to see what fprettify does. A quick demonstration:
 
-``` Fortran
+```Fortran
 program demo
 integer :: endif,if,elseif
 integer,DIMENSION(2) :: function
@@ -50,8 +49,10 @@ print*,endif
 endif
 end program
 ```
+
 ⇩⇩⇩⇩⇩⇩⇩⇩⇩⇩ `fprettify` ⇩⇩⇩⇩⇩⇩⇩⇩⇩⇩
-``` Fortran
+
+```Fortran
 program demo
    integer :: endif, if, elseif
    integer, DIMENSION(2) :: function
@@ -67,65 +68,74 @@ program demo
 end program
 ```
 
-
 ## Installation
 
 The latest release can be installed using pip:
-```
+
+```sh
 pip install --upgrade fprettify
 ```
 
 Installation from source requires Python Setuptools:
-```
+
+```sh
 ./setup.py install
 ```
 
 For local installation, use `--user` option.
 
-
 ## Command line tool
 
 Autoformat file1, file2, ... inplace by
-```
+
+```sh
 fprettify file1, file2, ...
 ```
+
 The default indent is 3. If you prefer something else, use `--indent n` argument.
 
 In order to apply fprettify recursively to an entire Fortran project instead of a single file, use the `-r` option.
 
 For more options, read
-```
+
+```sh
 fprettify -h
 ```
-
 
 ## Editor integration
 
 For editor integration, use
-```
+
+```sh
 fprettify --silent
 ```
+
 For instance, with Vim, use fprettify with `gq` by putting the following commands in your `.vimrc`:
+
 ```vim
 autocmd Filetype fortran setlocal formatprg=fprettify\ --silent
 ```
 
-
 ## Deactivation and manual formatting (experimental feature)
 
 fprettify can be deactivated for selected lines: a single line followed by an inline comment starting with `!&` is not auto-formatted and consecutive lines that are enclosed between two comment lines `!&<` and `!&>` are not auto-formatted. This is useful for cases where manual alignment is preferred over auto-formatting. Furthermore, deactivation is necessary when non-standard Fortran syntax (such as advanced usage of preprocessor directives) prevents proper formatting. As an example, consider the following snippet of fprettify formatted code:
+
 ```fortran
 A = [-1, 10, 0, &
      0, 1000, 0, &
      0, -1, 1]
 ```
+
 In order to manually align the columns, fprettify needs to be deactivated by
+
 ```fortran
 A = [-1,   10, 0, & !&
       0, 1000, 0, & !&
       0,   -1, 1]   !&
 ```
+
 or, equivalently by
+
 ```fortran
 !&<
 A = [-1,   10, 0, &
@@ -134,10 +144,8 @@ A = [-1,   10, 0, &
 !&>
 ```
 
-
 ## Contributing / Testing
 
 The testing mechanism allows you to easily test fprettify with any Fortran project of your choice. Simply clone or copy your entire project into `fortran_tests/before` and run `python setup.py test`. The directory `fortran_tests/after` contains the test output (reformatted Fortran files). If testing fails, please submit an issue!
-
 
 [![Code Climate](https://codeclimate.com/github/pseewald/fprettify/badges/gpa.svg)](https://codeclimate.com/github/pseewald/fprettify)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ pip install --upgrade fprettify
 Installation from source requires Python Setuptools:
 
 ```sh
-./setup.py install
+pip install .
 ```
 
 For local installation, use `--user` option.

--- a/environment.yml
+++ b/environment.yml
@@ -3,3 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - configargparse
+  - importlib-metadata  # [py<38]

--- a/fprettify/version.py
+++ b/fprettify/version.py
@@ -1,0 +1,10 @@
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ModuleNotFoundError:
+    from importlib_metadata import PackageNotFoundError, version
+try:
+    __version__ = version(__package__)
+except PackageNotFoundError:
+    from setuptools_scm import get_version
+
+    __version__ = get_version(root="..", relative_to=__file__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = [
+    "setuptools >= 45",
+    "wheel",
+    "setuptools_scm[toml] >= 6.2",
+    "setuptools_scm_git_archive",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "fprettify/_version.py"
+
+[tool.isort]
+profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,49 @@
+[metadata]
+name = fprettify
+url = https://github.com/pseewald/fprettify
+author = Patrick Seewald
+author_email = patrick.seewald@gmail.com
+description = auto-formatter for modern fortran source code
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = GPLv3
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    Topic :: Software Development :: Quality Assurance
+    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Environment :: Console
+    Operating System :: OS Independent
+keywords =
+    fortran
+    formatter
+project_urls =
+    Tracker = https://github.com/pseewald/fprettify/issues
+    Source Code = https://github.com/pseewald/fprettify
+
+[options]
+packages = find:
+python_requires = >= 3.5
+install_requires =
+    configargparse
+    importlib-metadata; python_version < "3.8"
+
+[options.entry_points]
+console_scripts =
+    fprettify = fprettify.__init__:run
+
+[options.extras_require]
+dev =
+    black
+    isort
+    pre-commit
+
+[flake8]
+max-line-length = 88
+extend-ignore = E203, E722

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ dev =
     black
     isort
     pre-commit
+    coveralls
 
 [flake8]
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -1,41 +1,4 @@
 #!/usr/bin/env python
 from setuptools import setup
-from codecs import open
-from os import path
 
-here = path.abspath(path.dirname(__file__))
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
-
-setup(name='fprettify',
-      version='0.3.7',
-      description='auto-formatter for modern fortran source code',
-      long_description=long_description,
-      long_description_content_type="text/markdown",
-      author='Patrick Seewald',
-      author_email='patrick.seewald@gmail.com',
-      license='GPLv3',
-      entry_points={'console_scripts': ['fprettify = fprettify:run']},
-      packages=['fprettify'],
-      install_requires=[
-          'configargparse',
-      ],
-      test_suite='fprettify.tests',
-      keywords='fortran format formatting auto-formatter indent',
-      url='https://github.com/pseewald/fprettify',
-      download_url='https://github.com/pseewald/fprettify/archive/v0.3.7.tar.gz',
-      classifiers=[
-          'Development Status :: 5 - Production/Stable',
-          'Intended Audience :: Developers',
-          'Topic :: Software Development :: Quality Assurance',
-          'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.5',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.8',
-          'Programming Language :: Python :: 3.9',
-          'Environment :: Console',
-          'Operating System :: OS Independent',
-      ]
-      )
+setup()


### PR DESCRIPTION
- [x] Moves the build from setup.py to setup.cfg and pyproject.toml, since setup.py will soon be deprecated.
- [x] Uses setuptools_scm for automatic version incrementation. Can be inferred from git and GitHub Releases
- [x] Updaes instructions on how to install

Fixes #132
Depends on #131 for README formatting

