### PR TITLE
allow named select case

### DIFF
--- a/fortran_tests/after/example.f90
+++ b/fortran_tests/after/example.f90
@@ -194,8 +194,8 @@ program example_prog
 ! example 4.1
    l = 0
    do r = 1, 10
-      select case (r)
-      case (1)
+      case_label: select case(r)
+      case (1) case_label
          do i = 1, 100; if (i <= 2) then! comment
                do j = 1, 5
                   do k = 1, 3
@@ -211,7 +211,7 @@ program example_prog
          end do
       case (2)
          l = i + j + k
-      end select
+      end select case_label
    end do
 
 ! example 4.2

--- a/fortran_tests/before/example.f90
+++ b/fortran_tests/before/example.f90
@@ -195,8 +195,8 @@ real(kind=dp) :: r1,   r2,  r3, r4, r5,  r6
 ! example 4.1
    l = 0
    do r = 1, 10
-         select case ( r )
-   case( 1)
+         case_label  :  select case ( r )
+   case( 1) case_label
            do i=1,100;if (i<=2) then! comment
           do j = 1,5
                     do   k= 1, 3
@@ -212,7 +212,7 @@ real(kind=dp) :: r1,   r2,  r3, r4, r5,  r6
            enddo
             case(2 )
            l = i+ j + k
-              end select
+             end select     case_label
                enddo
 
 ! example 4.2

--- a/fortran_tests/test_results/expected_results
+++ b/fortran_tests/test_results/expected_results
@@ -1,4 +1,4 @@
-example.f90 : f5b449553856f8e62b253402ed2189044554f53c9954aad045db44ff3c2d49b7
+example.f90 : 1df5c1b38944d87eb73c561a9e13e4ea644ed5027c74367e3edbbf3903509dc4
 RosettaCodeData/Task/100-doors/Fortran/100-doors-1.f : b44289edb55a75ca29407be3ca0d997119253d4c7adb5b3dfc1119944036ab0f
 RosettaCodeData/Task/100-doors/Fortran/100-doors-2.f : 263122b2af3e3637a7dab0bc0216dec27d76068b7352e9ab85e420de625408be
 RosettaCodeData/Task/24-game-Solve/Fortran/24-game-solve-1.f : 8927cfcfe15685f1513ed923b7ac38058358ec6586de83920679b537aa5b2d03

--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -112,10 +112,10 @@ DO_RE = re.compile(SOL_STR + r"(\w+\s*:)?\s*DO(" + EOL_STR + r"|\s+\w)", RE_FLAG
 ENDDO_RE = re.compile(SOL_STR + r"END\s*DO(\s+\w+)?" + EOL_STR, RE_FLAGS)
 
 SELCASE_RE = re.compile(
-    SOL_STR + r"SELECT\s*(CASE|RANK|TYPE)\s*\(.*\)" + EOL_STR, RE_FLAGS)
+    SOL_STR + r"(\w+\s*:)?\s*SELECT\s*(CASE|RANK|TYPE)\s*\(.*\)" + EOL_STR, RE_FLAGS)
 CASE_RE = re.compile(
-    SOL_STR + r"((CASE|RANK|TYPE\s+IS|CLASS\s+IS)\s*(\(.*\)|DEFAULT)|CLASS\s+DEFAULT)" + EOL_STR, RE_FLAGS)
-ENDSEL_RE = re.compile(SOL_STR + r"END\s*SELECT" + EOL_STR, RE_FLAGS)
+    SOL_STR + r"((CASE|RANK|TYPE\s+IS|CLASS\s+IS)\s*(\(.*\)|DEFAULT)|CLASS\s+DEFAULT)(\s+\w+)?" + EOL_STR, RE_FLAGS)
+ENDSEL_RE = re.compile(SOL_STR + r"END\s*SELECT(\s+\w+)?" + EOL_STR, RE_FLAGS)
 
 ASSOCIATE_RE = re.compile(SOL_STR + r"ASSOCIATE\s*\(.*\)" + EOL_STR, RE_FLAGS)
 ENDASSOCIATE_RE = re.compile(SOL_STR + r"END\s*ASSOCIATE" + EOL_STR, RE_FLAGS)
@@ -1308,7 +1308,7 @@ def add_whitespace_context(line, spacey):
 
     line = ''.join(line_parts)
 
-    for newre in [IF_RE, DO_RE, BLK_RE]:
+    for newre in [IF_RE, DO_RE, BLK_RE, SELCASE_RE]:
         if newre.search(line) and re.search(SOL_STR + r"\w+\s*:", line):
             line = ': '.join(_.strip() for _ in line.split(':', 1))
 


### PR DESCRIPTION
I've come across misalignments when `select case` blocks included a `name: ` with them, e.g.
```fortran
case_label: select case (r)
case (1) case_label
   <code>
case (2) case_label
   <mode code>
end select case case_label
```
Currently `fprettify` would not recognise those and not indent `<code>` or `<more code>`.

I've expanded what I guessed needs expanding and amended a _single_, simple test within `example.f90`. I've not checked other select statements apart from `select case`. The checksum is also updated accordingly.
 