### PR TITLE
Disable whitespace disrupting CUDA chevrons

### DIFF
--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -338,6 +338,8 @@ NML_RE = re.compile(r"(/\w+/)", RE_FLAGS)
 # find namelists and data statements
 NML_STMT_RE = re.compile(SOL_STR + r"NAMELIST.*/.*/", RE_FLAGS)
 DATA_STMT_RE = re.compile(SOL_STR + r"DATA\s+\w", RE_FLAGS)
+# find CUDA chevrons
+CUDA_CHEVRONS_RE = re.compile(r"<<<.*>>>", RE_FLAGS)
 
 ## Regexp for f90 keywords'
 F90_KEYWORDS_RE = re.compile(r"\b(" + "|".join((
@@ -1302,7 +1304,7 @@ def add_whitespace_context(line, spacey):
             # exclude comments, strings:
             if not STR_OPEN_RE.match(part):
                 # also exclude / if we see a namelist and data statement
-                if not ( NML_STMT_RE.match(line) or DATA_STMT_RE.match(line) ):
+                if not ( NML_STMT_RE.match(line) or DATA_STMT_RE.match(line) or CUDA_CHEVRONS_RE.search(line) ):
                     partsplit = lr_re.split(part)
                     line_parts[pos] = (' ' * spacey[n_op + 2]).join(partsplit)
 


### PR DESCRIPTION
Previously, fprettify did not understand CUDA fortran's triple-chevron syntax for calling kernel functions, e.g.
```fortran
call example_kernel<<<1, 1>>>(args)
```
As a result, each symbol in the chevrons `<<<` would have whitespace added, resulting in the incorrect syntax:
```fortran
call example_kernel <  <  < 1, 1 >  >  > (args)
```

This problem only occurs when adding whitespace around relational operators is enabled.

This commit adds an escape hatch to the function that handles whitespace around operators `add_whitespace_context` which disables the whitespace handling for any line that matches the REGEX "<<<.*>>>":

```python
CUDA_CHEVRONS_RE = re.compile(r"<<<.*>>>", RE_FLAGS)

...

if not ( ... or CUDA_CHEVRONS_RE.search(line) ):
```

This change should not break any Fortran syntax, however any relational operator that appears in a line that *also* features a triple-chevron will not be formatted, e.g.

```fortran
call example_kernel<<<1, 1>>>(3< 4, var1 ==var2)
```